### PR TITLE
Update to public seas

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -23,6 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[develop]"
         pip install git+https://github.com/NREL/electrolyzer.git
+        pip install https://github.com/NREL/SEAS/blob/main/SEAS.tar.gz?raw=true
     - name: Run tests and collect coverage
       run: |
         # -rA displays the captured output for all tests after they're run

--- a/docs/install_old.md
+++ b/docs/install_old.md
@@ -25,9 +25,9 @@ develop branch.
 SEAS is also required for hercules. To install 
 SEAS, use
 
-``` pip install git+https://github.nrel.gov/SEAS/SEAS.git@dv/emuwind ```
+``` pip install https://github.com/NREL/SEAS/blob/main/SEAS.tar.gz?raw=true ```
 
-If this fails, the following may work instead:
+If this fails, the following may work instead (but you need permissions):
 
 
 ```

--- a/docs/install_on_kestrel.md
+++ b/docs/install_on_kestrel.md
@@ -167,6 +167,14 @@ env_hercules()
 
 Go back to herc_root
 
+#### Install SEAS from public repo
+
+```
+pip install https://github.com/NREL/SEAS/blob/main/SEAS.tar.gz?raw=true
+```
+
+If this fails can also try but note need special permissions:
+
 ```
 git clone https://github.nrel.gov/SEAS/SEAS
 

--- a/tests/py_sims_test.py
+++ b/tests/py_sims_test.py
@@ -1,13 +1,14 @@
-import unittest
+import pytest
 
 from hercules import py_sims
 
-class TestPySims(unittest.TestCase):
 
-    def test_init_pysim(self):
+def test_init_pysim():
 
-        input_dict = dict()
-        input_dict['dt'] = 0.1
-        input_dict['py_sims'] = None
+    # Test that a pysim can be initated
 
-        py_sims.PySims(input_dict)
+    input_dict = dict()
+    input_dict['dt'] = 0.1
+    input_dict['py_sims'] = None
+
+    py_sims.PySims(input_dict)

--- a/tests/seas_test.py
+++ b/tests/seas_test.py
@@ -1,0 +1,9 @@
+import pytest
+
+from SEAS.federate_agent import FederateAgent
+
+def test_seas_import():
+
+    # Test that can import seas and declare a federate agent
+
+    FE = FederateAgent('test')


### PR DESCRIPTION
# Update to public version of SEAS

This pull request changes HERCULES code and documentation to us public-facing version of SEAS.  Specifically:

- Information on installing public version of SEAS added to documentation
- Install of public SEAS added to continuous integration
- A new pytest of SEAS added to tests folder

Note pulling to main so that this can be part of online documentation, I can back-merge to develop after merge

Thank you @dvaidhyn !