### PR TITLE
Add ruff linting, formatting and pre-commit hooks

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -24,6 +24,7 @@ jobs:
         pip install -e ".[develop]"
         pip install git+https://github.com/NREL/electrolyzer.git
         pip install https://github.com/NREL/SEAS/blob/main/SEAS.tar.gz?raw=true
+    - uses: pre-commit/action@v3.0.0
     - name: Run tests and collect coverage
       run: |
         # -rA displays the captured output for all tests after they're run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+
+repos:
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-executables-have-shebangs
+  - id: check-yaml
+    args: [--unsafe]
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: mixed-line-ending
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.1.7
+  hooks:
+    # Run the linter.
+    - id: ruff
+      types_or: [ python, pyi, jupyter ]
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[coverage.run]
+# Coverage.py configuration file
+# https://coverage.readthedocs.io/en/latest/config.html
+branch = true
+source = "hercules/*"
+omit = [
+    "setup.py",
+    "tests/*"
+]
+
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+filterwarnings = [
+    "ignore::DeprecationWarning:pandas.*:"
+]
+
+
+[tool.ruff]
+src = ["hercules", "tests"]
+line-length = 100
+target-version = "py310"
+extend-include = ["*.ipynb"]
+ignore-init-module-imports = true
+
+# See https://github.com/charliermarsh/ruff#supported-rules
+# for rules included and matching to prefix.
+select = ["E", "F", "I"]
+
+# F401 unused-import: Ignore until all used isort flags are adopted in ruff
+# ignore = ["F401"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+# fixable = ["A", "B", "C", "D", "E", "F"]
+fixable = ["E", "F", "I"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+
+[tool.ruff.isort]
+combine-as-imports = true
+known-first-party = ["flasc"]
+order-by-type = false
+
+# [tool.ruff.format]
+
+[tool.ruff.per-file-ignores]
+# Ignore `F401` (import violations) in all `__init__.py` files, and in `path/to/file.py`.
+"__init__.py" = ["F401"]


### PR DESCRIPTION
This pull request addresses Issue #45 by adding the helper files for ruff to implement linting, formatting and pre-commit and CI.  This will conform Hercules' coding style to that of FLORIS/FLASC.

Note will need to actually lint the files ahead of merging but waiting for a convenient moment to do all this