### PR TITLE
Stand-in AMR-wind uses stop time defined in amr_input.inp

### DIFF
--- a/example_case_folders/02_amr_wind_dummy_only/amr_input.inp
+++ b/example_case_folders/02_amr_wind_dummy_only/amr_input.inp
@@ -1,7 +1,7 @@
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            SIMULATION STOP            #
 #.......................................#
-time.stop_time               =   10800.0     # Max (simulated) time to evolve
+time.stop_time               =   20.0     # Max (simulated) time to evolve
 time.max_step                =   -1          # Max number of time steps
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/example_case_folders/02_amr_wind_dummy_only/amr_input.inp
+++ b/example_case_folders/02_amr_wind_dummy_only/amr_input.inp
@@ -1,7 +1,7 @@
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            SIMULATION STOP            #
 #.......................................#
-time.stop_time               =   20.0     # Max (simulated) time to evolve
+time.stop_time               =   100.0     # Max (simulated) time to evolve
 time.max_step                =   -1          # Max number of time steps
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/hercules/dummy_amr_wind.py
+++ b/hercules/dummy_amr_wind.py
@@ -177,7 +177,8 @@ class DummyAMRWind(FederateAgent):
 
         self.message_from_server = None
 
-        while self.absolute_helics_time < (self.endtime - self.starttime + 1):
+        #while self.absolute_helics_time < (self.endtime - self.starttime + 1):
+        while sim_time_s <= (self.endtime - self.starttime):
             # SIMULATE A CALCULATION STEP IN AMR WIND=========================
             logger.info("Calculating simulation time: %.1f" % sim_time_s)
 

--- a/hercules/dummy_amr_wind.py
+++ b/hercules/dummy_amr_wind.py
@@ -92,6 +92,11 @@ def read_amr_wind_input(amr_wind_input):
             if "helics.broker_port" in line:
                 broker_port = int(line.split()[2])
 
+        # Get the stop time
+        for line in Lines:
+            if "time.stop_time" in line:
+                stop_time = float(line.split()[2])
+
         return_dict = {
             "dt": dt,
             "num_turbines": num_turbines,
@@ -99,6 +104,7 @@ def read_amr_wind_input(amr_wind_input):
             "rotor_diameter": D,
             "turbine_locations": turbine_locations,
             "helics_port": broker_port,
+            "stop_time":stop_time,
         }
 
     return return_dict
@@ -308,7 +314,7 @@ class DummyAMRWind(FederateAgent):
 
 def launch_dummy_amr_wind(amr_input_file, amr_standin_data_file=None):
     temp = read_amr_wind_input(amr_input_file)
-    print(temp["helics_port"])
+
     config = {
         "name": "dummy_amr_wind",
         "gridpack": {},
@@ -322,7 +328,7 @@ def launch_dummy_amr_wind(amr_input_file, amr_standin_data_file=None):
         "publication_interval": 1,
         "endpoint_interval": 1,
         "starttime": 0,
-        "stoptime": 900,
+        "stoptime": temp["stop_time"],
         "Agent": "dummy_amr_wind",
     }
 


### PR DESCRIPTION
@brookeslawski raised the issue that the stop time is hardcoded in `launch_dummy_amr_wind()` (in dummy_amr_wind.py). As we are reading in other information from the amr_input file, this change also reads in the stop time and uses that.

Additionally, the while loop in `DummyAMRWind.run()` now uses `sim_time_s` as its counter to meet the stopping condition, rather than `absolute_helics_time`, because `absolute_helics_time` is counting twice as fast as `sim_time_s` and therefore ends the simulation at (approximately) half the intended runtime. This is likely related to #42 .

Ready for review and merge.