### PR TITLE
[BUG] Hotfix: track floris v4 change in input file "turbulence_intensities"

### DIFF
--- a/hercules/floris_standin.py
+++ b/hercules/floris_standin.py
@@ -295,7 +295,7 @@ default_floris_dict = {
         "wind_veer": 0.0,
         "wind_shear": 0.12,
         "air_density": 1.225,
-        "turbulence_intensity": 0.06,
+        "turbulence_intensities": [0.06],
         "reference_wind_height": 90.0,
     },
     "name": "GCH_for_FlorisStandin",


### PR DESCRIPTION
Recent changes to the [FLORIS v4 branch](https://github.com/NREL/floris) mean that the stand-in broke. This fixes that issue. This will likely won't be the last time this happens before FLORIS v4 is released.