### PR TITLE
[BUGFIX] Reenable AMR-Wind by setting up empty power_setpoints

### DIFF
--- a/hercules/amr_wind_standin.py
+++ b/hercules/amr_wind_standin.py
@@ -189,8 +189,16 @@ class AMRWindStandin(FederateAgent):
 
             # Compute the turbine power using a simple formula
             if self.message_from_server is not None:
-                yaw_angles = self.message_from_server[-2*self.num_turbines:-self.num_turbines]
-                power_setpoints = self.message_from_server[-self.num_turbines:]
+                if len(self.message_from_server) >= 3 + self.num_turbines:
+                    yaw_angles = self.message_from_server[3:3 + self.num_turbines]
+                else:
+                    yaw_angles = None
+                if len(self.message_from_server) >= 3 + 2*self.num_turbines:
+                    power_setpoints = self.message_from_server[
+                        3 + self.num_turbines:3 + 2*self.num_turbines
+                    ]
+                else:
+                    power_setpoints = None
             else:
                 yaw_angles = None
                 power_setpoints = None

--- a/hercules/emulator.py
+++ b/hercules/emulator.py
@@ -388,11 +388,10 @@ class Emulator(FederateAgent):
                 "turbine_power_setpoints"
             ]
         else:  # set yaw_angles based on self.wind_direction
-            power_setpoints = [None] * self.num_turbines
+            power_setpoints = [] * self.num_turbines
 
         # Send timing and yaw information to AMRWind via helics
         # publish on topic: control
-        # TODO: power_setpoints part will not work with AMRWind proper.
         tmp = np.array(
             [self.absolute_helics_time, self.wind_speed, self.wind_direction]
             + yaw_angles

--- a/hercules/emulator.py
+++ b/hercules/emulator.py
@@ -387,7 +387,7 @@ class Emulator(FederateAgent):
             power_setpoints = self.main_dict["hercules_comms"]["amr_wind"][self.amr_wind_names[0]][
                 "turbine_power_setpoints"
             ]
-        else:  # set yaw_angles based on self.wind_direction
+        else:  # pass no power setpoints
             power_setpoints = [] * self.num_turbines
 
         # Send timing and yaw information to AMRWind via helics


### PR DESCRIPTION
#76 Enabled passing power_setpoints to the `FlorisStandin`; however, @jfrederik-nrel noticed that this created a bug when running with AMR-Wind, because the helics connection in AMR-Wind was not expecting extra elements in the `"control"` message being passed to it.

This PR fixes that bug by handling variable length control signals (without `power_setpoints` for AMR-Wind; and (optionally) with `power_setpoints` for the `FlorisStandin`).