### PR TITLE
Smooth output of FlorisStandin to prevent oscilations in closed-loop response

### DIFF
--- a/hercules/floris_standin.py
+++ b/hercules/floris_standin.py
@@ -149,6 +149,7 @@ class FlorisStandin(AMRWindStandin):
 
         # Initialize storage
         self.yaw_angles_stored = [0.0] * self.num_turbines
+        self.turbine_powers_prev = np.zeros(self.num_turbines)
 
     def get_step(self, sim_time_s, yaw_angles=None, power_setpoints=None):
         """Retreive or calculate wind speed, direction, and turbine powers
@@ -218,7 +219,20 @@ class FlorisStandin(AMRWindStandin):
             power_setpoints=power_setpoints
         )
         self.fi.run()
-        turbine_powers = (self.fi.get_turbine_powers() / 1000).flatten().tolist()  # in kW
+        turbine_powers_floris = (self.fi.get_turbine_powers() / 1000).flatten()  # in kW
+
+        smooth_output = True
+        if smooth_output:
+            a = 0.5
+            print("power setpoints:", power_setpoints)
+            print("floris power:", turbine_powers_floris)
+            print("previous power:", self.turbine_powers_prev)
+            turbine_powers = (a*self.turbine_powers_prev + (1-a)*turbine_powers_floris)
+            print("smoothed power:", turbine_powers)
+            self.turbine_powers_prev = turbine_powers
+        else:
+            turbine_powers = turbine_powers_floris.tolist()
+        turbine_powers = turbine_powers.tolist()
 
         return (
             amr_wind_speed,

--- a/tests/floris_standin_test.py
+++ b/tests/floris_standin_test.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from floris.tools import FlorisInterface
+from floris import FlorisModel
 from hercules.amr_wind_standin import AMRWindStandin
 from hercules.floris_standin import (
     construct_floris_from_amr_input,
@@ -33,8 +33,8 @@ CONFIG = {
 
 
 def test_construct_floris_from_amr_input():
-    fi_test = construct_floris_from_amr_input(AMR_INPUT)
-    assert isinstance(fi_test, FlorisInterface)
+    fmodel_test = construct_floris_from_amr_input(AMR_INPUT)
+    assert isinstance(fmodel_test, FlorisModel)
 
 
 def test_FlorisStandin_instantiation():
@@ -46,25 +46,25 @@ def test_FlorisStandin_instantiation():
     assert isinstance(floris_standin, AMRWindStandin)
 
     # Get FLORIS equivalent, match layout and turbines
-    fi_true = FlorisInterface(default_floris_dict)
-    fi_true.set(
-        layout_x=floris_standin.fi.layout_x,
-        layout_y=floris_standin.fi.layout_y,
-        turbine_type=floris_standin.fi.floris.farm.turbine_definitions,
+    fmodel_true = FlorisModel(default_floris_dict)
+    fmodel_true.set(
+        layout_x=floris_standin.fmodel.layout_x,
+        layout_y=floris_standin.fmodel.layout_y,
+        turbine_type=floris_standin.fmodel.core.farm.turbine_definitions,
     )
 
-    assert fi_true.floris.as_dict() == floris_standin.fi.floris.as_dict()
+    assert fmodel_true.core.as_dict() == floris_standin.fmodel.core.as_dict()
 
 
 def test_FlorisStandin_get_step_yaw_angles():
     floris_standin = FlorisStandin(CONFIG, AMR_INPUT)
 
     # Get FLORIS equivalent, match layout and turbines
-    fi_true = FlorisInterface(default_floris_dict)
-    fi_true.set(
-        layout_x=floris_standin.fi.layout_x,
-        layout_y=floris_standin.fi.layout_y,
-        turbine_type=floris_standin.fi.floris.farm.turbine_definitions,
+    fmodel_true = FlorisModel(default_floris_dict)
+    fmodel_true.set(
+        layout_x=floris_standin.fmodel.layout_x,
+        layout_y=floris_standin.fmodel.layout_y,
+        turbine_type=floris_standin.fmodel.core.farm.turbine_definitions,
     )
 
     default_wind_direction = 240.0  # Matches default in FlorisStandin
@@ -72,14 +72,14 @@ def test_FlorisStandin_get_step_yaw_angles():
 
     # Test with None yaw angles
     fs_ws, fs_wd, fs_tp, fs_twd = floris_standin.get_step(5.0)
-    fi_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
-    fi_true.run()
-    fi_true_tp = fi_true.get_turbine_powers() / 1000 # kW expected
+    fmodel_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
+    fmodel_true.run()
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000 # kW expected
 
     assert fs_ws == default_wind_speed
     assert fs_wd == default_wind_direction
     assert fs_twd == [default_wind_direction] * 2
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Test with any "no value" yaw angles (should apply no yaw angle)
     fs_ws, fs_wd, fs_tp, fs_twd = floris_standin.get_step(5.0, yaw_angles=[-1000, 20])
@@ -87,37 +87,37 @@ def test_FlorisStandin_get_step_yaw_angles():
     assert fs_ws == default_wind_speed
     assert fs_wd == default_wind_direction
     assert fs_twd == [default_wind_direction] * 2
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Test with aligned turbines
     yaw_angles = [240.0, 240.0]
     fs_ws, fs_wd, fs_tp, fs_twd = floris_standin.get_step(5.0, yaw_angles)
-    fi_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
-    fi_true.run()
-    fi_true_tp = fi_true.get_turbine_powers() / 1000 # kW expected
+    fmodel_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
+    fmodel_true.run()
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000 # kW expected
 
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Test with misaligned turbines
     yaw_angles = [260.0, 230.0]
     fs_ws, fs_wd, fs_tp, fs_twd = floris_standin.get_step(5.0, yaw_angles)
-    fi_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
-    fi_true.run()  # Don't expect to work
-    fi_true_tp = fi_true.get_turbine_powers() / 1000
-    assert not np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    fmodel_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
+    fmodel_true.run()  # Don't expect to work
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000
+    assert not np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Correct yaw angles
-    fi_true.set(yaw_angles=default_wind_direction - np.array([yaw_angles]))
-    fi_true.run()
-    fi_true_tp = fi_true.get_turbine_powers() / 1000 # kW expected
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    fmodel_true.set(yaw_angles=default_wind_direction - np.array([yaw_angles]))
+    fmodel_true.run()
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000 # kW expected
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Test that yaw angles are maintained from the previous step if large misalignments are provided
     yaw_angles = [0.0, 10.0]
     _, _, fs_tp2, _ = floris_standin.get_step(5.0, yaw_angles)
     assert np.allclose(fs_tp, fs_tp2)
     assert np.allclose(
-        default_wind_direction-floris_standin.fi.floris.farm.yaw_angles,
+        default_wind_direction-floris_standin.fmodel.core.farm.yaw_angles,
         [260.0, 230.0]
     )
 
@@ -125,11 +125,11 @@ def test_FlorisStandin_get_step_power_setpoints():
     floris_standin = FlorisStandin(CONFIG, AMR_INPUT)
 
     # Get FLORIS equivalent, match layout and turbines
-    fi_true = FlorisInterface(default_floris_dict)
-    fi_true.set(
-        layout_x=floris_standin.fi.layout_x,
-        layout_y=floris_standin.fi.layout_y,
-        turbine_type=floris_standin.fi.floris.farm.turbine_definitions,
+    fmodel_true = FlorisModel(default_floris_dict)
+    fmodel_true.set(
+        layout_x=floris_standin.fmodel.layout_x,
+        layout_y=floris_standin.fmodel.layout_y,
+        turbine_type=floris_standin.fmodel.core.farm.turbine_definitions,
     )
 
     default_wind_direction = 240.0  # Matches default in FlorisStandin
@@ -137,23 +137,23 @@ def test_FlorisStandin_get_step_power_setpoints():
 
     # Test with power setpoints
     fs_ws, fs_wd, fs_tp, fs_twd = floris_standin.get_step(5.0, power_setpoints=[1e3, 1e3])
-    fi_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
-    fi_true.run() # don't expect to work
-    fi_true_tp = fi_true.get_turbine_powers() / 1000
-    assert not np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    fmodel_true.set(wind_speeds=[default_wind_speed], wind_directions=[default_wind_direction])
+    fmodel_true.run() # don't expect to work
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000
+    assert not np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Correct power setpoints
-    fi_true.set(power_setpoints=np.array([[1e6, 1e6]]))
-    fi_true.run()
-    fi_true_tp = fi_true.get_turbine_powers() / 1000 # kW expected
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    fmodel_true.set(power_setpoints=np.array([[1e6, 1e6]]))
+    fmodel_true.run()
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000 # kW expected
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Mixed power setpoints
     fs_ws, fs_wd, fs_tp, fs_twd = floris_standin.get_step(5.0, power_setpoints=[None, 1e3])
-    fi_true.set(power_setpoints=np.array([[None, 1e6]]))
-    fi_true.run()
-    fi_true_tp = fi_true.get_turbine_powers() / 1000
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    fmodel_true.set(power_setpoints=np.array([[None, 1e6]]))
+    fmodel_true.run()
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
     # Test with invalid combination of yaw angles and power setpoints
     with pytest.raises(ValueError):
@@ -169,13 +169,13 @@ def test_FlorisStandin_get_step_power_setpoints():
     )
     floris_power_setpoints = np.array([power_setpoints])
     floris_power_setpoints[0,1] *= 1e3 
-    fi_true.set(
+    fmodel_true.set(
         yaw_angles=default_wind_direction - np.array([yaw_angles]),
         power_setpoints=floris_power_setpoints
     )
-    fi_true.run()
-    fi_true_tp = fi_true.get_turbine_powers() / 1000
-    assert np.allclose(fs_tp, fi_true_tp.flatten().tolist())
+    fmodel_true.run()
+    fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000
+    assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
 
 def test_FlorisStandin_with_standin_data_yaw_angles():

--- a/tests/floris_standin_test.py
+++ b/tests/floris_standin_test.py
@@ -57,7 +57,7 @@ def test_FlorisStandin_instantiation():
 
 
 def test_FlorisStandin_get_step_yaw_angles():
-    floris_standin = FlorisStandin(CONFIG, AMR_INPUT)
+    floris_standin = FlorisStandin(CONFIG, AMR_INPUT, smoothing_coefficient=0.0)
 
     # Get FLORIS equivalent, match layout and turbines
     fmodel_true = FlorisModel(default_floris_dict)
@@ -122,7 +122,7 @@ def test_FlorisStandin_get_step_yaw_angles():
     )
 
 def test_FlorisStandin_get_step_power_setpoints():
-    floris_standin = FlorisStandin(CONFIG, AMR_INPUT)
+    floris_standin = FlorisStandin(CONFIG, AMR_INPUT, smoothing_coefficient=0.0)
 
     # Get FLORIS equivalent, match layout and turbines
     fmodel_true = FlorisModel(default_floris_dict)
@@ -179,7 +179,7 @@ def test_FlorisStandin_get_step_power_setpoints():
 
 
 def test_FlorisStandin_with_standin_data_yaw_angles():
-    floris_standin = FlorisStandin(CONFIG, AMR_INPUT, AMR_EXTERNAL_DATA)
+    floris_standin = FlorisStandin(CONFIG, AMR_INPUT, AMR_EXTERNAL_DATA, smoothing_coefficient=0.0)
 
     yaw_angles_all = [
         [240.0, 240.0],
@@ -231,7 +231,7 @@ def test_FlorisStandin_with_standin_data_yaw_angles():
     assert fs_tp_all[9, :].sum() > fs_tp_all[7, :].sum()
 
 def test_FlorisStandin_with_standin_data_power_setpoints():
-    floris_standin = FlorisStandin(CONFIG, AMR_INPUT, AMR_EXTERNAL_DATA)
+    floris_standin = FlorisStandin(CONFIG, AMR_INPUT, AMR_EXTERNAL_DATA, smoothing_coefficient=0.0)
 
     power_setpoints_all = [
         [None, None],

--- a/tests/floris_standin_test.py
+++ b/tests/floris_standin_test.py
@@ -276,3 +276,25 @@ def test_FlorisStandin_with_standin_data_power_setpoints():
     assert (fs_tp_all[6, :] == 1e3).all()
     assert fs_tp_all[7, 0] > 1e3
     assert fs_tp_all[7, 1] <= 1e3
+
+def test_FlorisStandin_smoothing_coefficient():
+    floris_standin_no_smoothing = FlorisStandin(CONFIG, AMR_INPUT, smoothing_coefficient=0.0)
+    floris_standin_default_smoothing = FlorisStandin(CONFIG, AMR_INPUT)
+    floris_standin_heavy_smoothing = FlorisStandin(CONFIG, AMR_INPUT, smoothing_coefficient=0.9)
+
+    # Start at zero power
+    floris_standin_no_smoothing.turbine_powers_prev = np.zeros(2)
+    floris_standin_default_smoothing.turbine_powers_prev = np.zeros(2)
+    floris_standin_heavy_smoothing.turbine_powers_prev = np.zeros(2)
+
+    # Step forward
+    fs_tp_no_smoothing = floris_standin_no_smoothing.get_step(1.0)[2]
+    fs_tp_default_smoothing = floris_standin_default_smoothing.get_step(1.0)[2]
+    fs_tp_heavy_smoothing = floris_standin_heavy_smoothing.get_step(1.0)[2]
+
+    # Check smoothing ordering correct
+    assert (np.array(fs_tp_no_smoothing) > np.array(fs_tp_default_smoothing)).all()
+    assert (np.array(fs_tp_default_smoothing) > np.array(fs_tp_heavy_smoothing)).all()
+
+    # Check magnitude is correct
+    assert np.allclose(0.1*np.array(fs_tp_no_smoothing), np.array(fs_tp_heavy_smoothing))


### PR DESCRIPTION
The `FlorisStandin` is a steady-state model standing in for a the dynamic AMR-Wind model. We (@genevievestarke ) have been finding that this can lead to poor performance in simple closed-loop controllers, which I think is because the plant model essentially has infinite bandwidth, which, when combined with an infinite bandwidth controller (such as the [wind farm power tracking controller implemented in WHOC](https://github.com/NREL/wind-hybrid-open-controller/blob/develop/whoc/controllers/wind_farm_power_tracking_controller.py), which is essentially a proportional controller), appears to lead to a closed-loop system that is marginally stable---see below, which comes from running the [wind farm power tracking example in WHOC](https://github.com/NREL/wind-hybrid-open-controller/tree/develop/examples/wind_farm_power_tracking_florisstandin) with the wind speed at 11m/s, rather than 8m/s.

![wf-power-tracking-plot_smoothing0](https://github.com/NREL/hercules/assets/39596329/a17535d6-b780-4a29-a4e1-a1f99e7c8e6d)


To solve this issue, this PR "smooths" the output from the `FlorisStandin` model by applying a first order filter to the output power to give the open-loop system a finite bandwidth; this dampens oscillations in the closed-loop system (or removes oscillations entirely). This damping is artificial, in the sense that it is not a direct output from FLORIS; however, any real system with dynamics will have a finite bandwidth, so this update makes the `FlorisStandin` slightly more realistic. The level of smoothing is controllable with the `smoothing_coefficient`, which users can set between 0 (no smoothing) and 1 (as the `smoothing_coefficient` approaches 1, smoothing becomes very heavy).

Using the default `smoothing_coefficient` (0.5) now results in the following (note that Open Loop and Closed Loop control appear similar (both able to achieve the farm setpoint) here because, at 11m/s, there is sufficient resource for the Open Loop controller to achieve the demanded setpoint also. This is not a characteristic of the change to `FlorisStandin`).

![wf-power-tracking-plot_smoothing1](https://github.com/NREL/hercules/assets/39596329/2f88bf0c-2f84-4a73-8041-048bb98612cb)


## Other notes
This pull request additionally updates the `FlorisStandin` to be compatible with the latest changes in [FLORIS v4](https://github.com/NREL/floris/tree/v4).

