### PR TITLE
[BUGFIX] Create outputs folder in examples to avoid error when output file does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,9 +40,9 @@ hercules/local_amr_wind_demo/sample_copy.nc
 # Some output files to ignore
 t_00*
 logdummy
-loghercules
+loghercules*
 logstandin
-logfloris
+logfloris*
 *echo
 *out-example.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ hercules/local_amr_wind_demo/sample_copy.nc
 t_00*
 logdummy
 loghercules*
-logstandin
+logstandin*
 logfloris*
 *echo
 *out-example.json

--- a/example_case_folders/02_amr_wind_standin_only/bash_script.sh
+++ b/example_case_folders/02_amr_wind_standin_only/bash_script.sh
@@ -8,6 +8,7 @@ conda activate hercules
 export HELICS_PORT=32000
 
 #make sure you use the same port number in the amr_input.inp and hercules_input_000.yaml files. 
+rm loghercules logstandin
 
 # Set up the helics broker
 helics_broker -t zmq  -f 2 --loglevel="debug" --local_port=$HELICS_PORT & 

--- a/hercules/amr_wind_standin.py
+++ b/hercules/amr_wind_standin.py
@@ -33,6 +33,7 @@ from SEAS.federate_agent import FederateAgent
 
 # Set up the logger
 # Useful for when running on eagle
+Path("outputs").mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
@@ -114,8 +115,6 @@ def read_amr_wind_input(amr_wind_input):
 
 class AMRWindStandin(FederateAgent):
     def __init__(self, config_dict, amr_wind_input, amr_standin_data_file=None):
-        # Ensure outputs folder exists
-        Path("outputs").mkdir(parents=True, exist_ok=True)
 
         super(AMRWindStandin, self).__init__(
             name=config_dict["name"],

--- a/hercules/emulator.py
+++ b/hercules/emulator.py
@@ -10,6 +10,7 @@ from SEAS.federate_agent import FederateAgent
 
 LOGFILE = str(dt.datetime.now()).replace(":", "_").replace(" ", "_").replace(".", "_")
 
+Path("outputs").mkdir(parents=True, exist_ok=True)
 
 class Emulator(FederateAgent):
     def __init__(self, controller, py_sims, input_dict):


### PR DESCRIPTION
A bug was introduced in #84 that means that the AMRWindStandin examples need to be run twice to work.

The issue is that the 
```python
logging.basicConfig(
    level=logging.DEBUG,
    format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
    datefmt="%Y-%m-%d %H:%M",
    filename="outputs/log_test_client.log",
    filemode="w",
)
logger = logging.getLogger("amr_wind_standin")
```
at the top of amr_wind_standin.py assumes that the folder outputs/ already exists; however, it is not created until `AMRWindStandin` is instantiated. 

To resolve the issue, we've added the creation of the outputs folder above this code, as well as added it to `emulator.py` in case the emulator is run without the `AMRWindStandin`. Additionally, the `.gitignore` is updated to ignore an log files beginning with `loghercules`, `logstandin`, or `logfloris`.