### PR TITLE
Change FLORIS to a "regular" requirement

### DIFF
--- a/docs/install_local.md
+++ b/docs/install_local.md
@@ -68,13 +68,6 @@ NREL's PySAM software is also required for hercules. To install, use
 pip install nrel-pysam==4.2.0
 ```
 
-You may also want to run the FLORIS standin for AMR-Wind for a steady-state representation 
-of wind farm flows. In this case, run
-```
-pip install git+https://github.com/NREL/floris.git@v4
-```
-to get the correct branch of FLORIS installed.
-
 If you run hercules and get an error that `pyyaml` is missing, you may also need to install it using
 ```
 conda install -c conda-forge pyyaml

--- a/docs/install_on_kestrel.md
+++ b/docs/install_on_kestrel.md
@@ -98,16 +98,6 @@ If you run hercules and get an error that `pyyaml` is missing, you may also need
 ```
 conda install -c conda-forge pyyaml
 ```
-### Install FLORIS 
-You may also want to run the FLORIS standin for AMR-Wind for a steady-state representation  of wind farm flows. 
-In this case, go back to herc_root,
-Then run
-```
-pip install git+https://github.com/NREL/floris.git@v4
-```
-to get the correct branch of FLORIS installed.
-
-Note that that pyyaml package is also required for FLORIS. 
 
 ### Install the NREL Wind Hybrid Open Controller (WHOC)
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ REQUIRED = [
     "numpy~=1.20",
     "matplotlib~=3.0",
     "pandas~=2.0",
+    "floris",
     "nrel-pysam~=4.2",
     # "dash>=2.0.0",
     # GUI Stuff

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ REQUIRED = [
     "numpy~=1.20",
     "matplotlib~=3.0",
     "pandas~=2.0",
-    "floris",
+    "floris>=4",
     "nrel-pysam~=4.2",
     # "dash>=2.0.0",
     # GUI Stuff

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ REQUIRED = [
     "numpy~=1.20",
     "matplotlib~=3.0",
     "pandas~=2.0",
-    "floris>=4",
+    "floris~=4.0",
     "nrel-pysam~=4.2",
     # "dash>=2.0.0",
     # GUI Stuff


### PR DESCRIPTION
Now that FLORIS v4 has been released, this PR switches the FLORIS installation requirement to the "normal" method for installing packages from PyPI.

I've checked that if I clone this branch; create a fresh environment; and `pip install -e hercules`, the correct version of FLORIS is installed.