### PR TITLE
Add external controls for solar PySAM module

### DIFF
--- a/hercules/emulator.py
+++ b/hercules/emulator.py
@@ -290,6 +290,9 @@ class Emulator(FederateAgent):
         self.main_dict["hercules_comms"]["amr_wind"][self.amr_wind_names[0]][
             "wind_direction"
         ] = wind_direction_amr_wind
+        self.main_dict["hercules_comms"]["amr_wind"][self.amr_wind_names[0]][
+            "wind_speed"
+        ] = wind_speed_amr_wind
 
         return None
 

--- a/hercules/python_simulators/solar_pysam.py
+++ b/hercules/python_simulators/solar_pysam.py
@@ -162,7 +162,7 @@ class SolarPySAM:
         print("self.power_mw = ", self.power_mw)
 
         # Apply control, if setpoint is provided
-        if "solar_setpoint_mw" in inputs["py_sims"]["inputs"]:
+        if "py_sims" in inputs and "solar_setpoint_mw" in inputs["py_sims"]["inputs"]:
             P_setpoint = inputs["py_sims"]["inputs"]["solar_setpoint_mw"]
         elif "external_signals" in inputs.keys():
             if "solar_power_reference_mw" in inputs["external_signals"].keys():

--- a/hercules/python_simulators/solar_pysam.py
+++ b/hercules/python_simulators/solar_pysam.py
@@ -68,7 +68,7 @@ class SolarPySAM:
             "aoi": self.aoi,
         }
     
-    def control(self, power_setpoint_mw):
+    def control(self, power_setpoint_mw=None):
         """
         Low-level controller to enforce PV plant power setpoints
         Notes:
@@ -79,10 +79,13 @@ class SolarPySAM:
         - power_setpoint_mw: [MW] the desired total PV plant output
         """
         # modify power output based on setpoint
-        if self.power_mw > power_setpoint_mw:
-            self.power_mw = power_setpoint_mw
-            # Keep track of power that could go to charging battery
-            self.excess_power = self.power_mw - power_setpoint_mw 
+        if power_setpoint_mw is not None:
+            print('power_setpoint = ', power_setpoint_mw)
+            if self.power_mw > power_setpoint_mw:
+                self.power_mw = power_setpoint_mw
+                # Keep track of power that could go to charging battery
+                self.excess_power = self.power_mw - power_setpoint_mw
+            print('self.power_mw after control = ',self.power_mw)
 
     def step(self, inputs):
         # print('-------------------')
@@ -158,15 +161,15 @@ class SolarPySAM:
         # self.dc_power_mw = dc[0]
         print("self.power_mw = ", self.power_mw)
 
-        # print("inputs[external_signals]",inputs["external_signals"])
-        if "external_signals" in inputs.keys():
+        # Apply control, if setpoint is provided
+        if "solar_setpoint_mw" in inputs["py_sims"]["inputs"]:
+            P_setpoint = inputs["py_sims"]["inputs"]["solar_setpoint_mw"]
+        elif "external_signals" in inputs.keys():
             if "solar_power_reference_mw" in inputs["external_signals"].keys():
                 P_setpoint = inputs["external_signals"]["solar_power_reference_mw"]
-                print('power_setpoint = ',P_setpoint)
-
-                self.control(P_setpoint)
-
-                print('self.power_mw after control = ',self.power_mw)
+        else:
+            P_setpoint = None
+        self.control(P_setpoint)
         
         if self.power_mw < 0.0:
             self.power_mw = 0.0

--- a/tests/python_simulators_test/solar_pysam_test.py
+++ b/tests/python_simulators_test/solar_pysam_test.py
@@ -90,3 +90,9 @@ def test_step(SPS: SolarPySAM):
     assert_almost_equal(SPS.power_mw, 32.17650018440107, decimal=8)
     # assert_almost_equal(SPS.dc_power_mw, 33.26240852125279, decimal=8)
     assert_almost_equal(SPS.ghi, 68.23037719726561, decimal=8)
+
+def test_control(SPS: SolarPySAM):
+    power_setpoint_mw = 30
+    step_inputs = {"time": 0, "py_sims": {"inputs": {"solar_setpoint_mw": power_setpoint_mw}}}
+    SPS.step(step_inputs)
+    assert_almost_equal(SPS.power_mw, power_setpoint_mw, decimal=8)


### PR DESCRIPTION
Adds the ability to provide a control setpoint to the solar module. The 07_floris_standin_and_solar_pysam example still runs as expected, and I've added a small test to make sure that the control setpoint is adhered to when passed, so I think this is ready for review.

NOTE: I've also saved the AMR wind speed (or stand-in wind speed) on the Hercules main dict for use in controllers that need (an estimate of) the free stream wind speed.