### PR TITLE
[BUGFIX] Force `yaw_angles` to zero in `FlorisStandin` when `power_setpoints` passed

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -33,7 +33,7 @@ jobs:
       run: |
         # -rA displays the captured output for all tests after they're run
         # See the docs: https://doc.pytest.org/en/latest/reference/reference.html#command-line-flags
-        pytest -rA tests/
+        pytest -vv -rA tests/
     - name: Generate coverage report
       # Run these tests on unit tests only so that we avoid inflating our code
       # coverage through the regression tests

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -27,7 +27,7 @@ jobs:
 #    - uses: pre-commit/action@v3.0.0
     - name: Run ruff
       run: |
-        ruff .
+        ruff check .
 #        ruff format
     - name: Run tests and collect coverage
       run: |

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -33,7 +33,7 @@ jobs:
       run: |
         # -rA displays the captured output for all tests after they're run
         # See the docs: https://doc.pytest.org/en/latest/reference/reference.html#command-line-flags
-        pytest -vv -rA tests/
+        pytest -rA tests/
     - name: Generate coverage report
       # Run these tests on unit tests only so that we avoid inflating our code
       # coverage through the regression tests

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -24,7 +24,6 @@ jobs:
         pip install -e ".[develop]"
         pip install git+https://github.com/NREL/electrolyzer.git
         pip install https://github.com/NREL/SEAS/blob/main/SEAS.tar.gz?raw=true
-        pip install git+https://github.com/NREL/floris.git@v4
 #    - uses: pre-commit/action@v3.0.0
     - name: Run ruff
       run: |

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: False
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/hercules/floris_standin.py
+++ b/hercules/floris_standin.py
@@ -208,6 +208,13 @@ class FlorisStandin(AMRWindStandin):
 
         turbine_wind_directions = [amr_wind_direction] * self.num_turbines
 
+        if power_setpoints is None or (np.array(power_setpoints) == 1e9).all():
+            pass # No conflict with yaw angles
+        else:
+            # Cannot currently handle both power setpoints and nonzero yaw angles. 
+            # If power setpoints are provided, overwrite any yaw angles.
+            yaw_angles = None
+
         if yaw_angles is None or (np.array(yaw_angles) == -1000).any():
             # Note: -1000 is the "no value" flag for yaw_angles (NaNs not handled well)
             yaw_misalignments = None # Floris will remember the previous yaw angles

--- a/hercules/floris_standin.py
+++ b/hercules/floris_standin.py
@@ -208,15 +208,23 @@ class FlorisStandin(AMRWindStandin):
 
         turbine_wind_directions = [amr_wind_direction] * self.num_turbines
 
-        if power_setpoints is None or (np.array(power_setpoints) == 1e9).all():
+        if power_setpoints is None or yaw_angles is None:
+            pass # No conflict with yaw angles
+        elif (
+            (((np.array(power_setpoints) == 1e9)
+              | (np.array([ps is None for ps in power_setpoints])))
+            | ((np.array(yaw_angles) == -1000) | (np.array([ya is None for ya in yaw_angles])) |
+               (np.array(yaw_angles) == amr_wind_direction))
+            ).all()
+        ):
             pass # No conflict with yaw angles
         else:
             # Cannot currently handle both power setpoints and nonzero yaw angles. 
             # If power setpoints are provided, overwrite any yaw angles.
             logger.warning((
-                "Received combination of power_setpoints and nonzero yaw angles, "
-                +"which can not currently be handled by the FlorisStandin. Setting "
-                +"yaw angles to None."
+                "Received combination of power_setpoints and nonzero yaw_angles for some turbines, "
+                +"which can not currently be handled by the FlorisStandin. Setting yaw_angles to "
+                +"None."
             ))
             yaw_angles = None
 

--- a/hercules/floris_standin.py
+++ b/hercules/floris_standin.py
@@ -213,6 +213,11 @@ class FlorisStandin(AMRWindStandin):
         else:
             # Cannot currently handle both power setpoints and nonzero yaw angles. 
             # If power setpoints are provided, overwrite any yaw angles.
+            logger.warning((
+                "Received combination of power_setpoints and nonzero yaw angles, "
+                +"which can not currently be handled by the FlorisStandin. Setting "
+                +"yaw angles to None."
+            ))
             yaw_angles = None
 
         if yaw_angles is None or (np.array(yaw_angles) == -1000).any():

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRES_PYTHON = ">=3.6.0,<3.12.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy~=1.20",
-    "matplotlib~=2.0",
+    "matplotlib~=3.0",
     "pandas~=2.0",
     "floris~=4.0",
     "nrel-pysam~=4.2",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRES_PYTHON = ">=3.6.0,<3.12.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy~=1.20",
-    "matplotlib~=3.0",
+    "matplotlib==3.8",
     "pandas~=2.0",
     "floris~=4.0",
     "nrel-pysam~=4.2",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRES_PYTHON = ">=3.6.0,<3.12.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy~=1.20",
-    "matplotlib==3.8",
+    "matplotlib~=2.0",
     "pandas~=2.0",
     "floris~=4.0",
     "nrel-pysam~=4.2",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRES_PYTHON = ">=3.6.0,<3.12.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy~=1.20",
-    "matplotlib==3.6",
+    "matplotlib~=3.0",
     "pandas~=2.0",
     "floris~=4.0",
     "nrel-pysam~=4.2",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ REQUIRES_PYTHON = ">=3.6.0,<3.12.0"
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy~=1.20",
-    "matplotlib~=3.0",
+    "matplotlib==3.6",
     "pandas~=2.0",
     "floris~=4.0",
     "nrel-pysam~=4.2",

--- a/tests/floris_standin_test.py
+++ b/tests/floris_standin_test.py
@@ -1,8 +1,7 @@
+import logging
 from pathlib import Path
 
-import logging
 import numpy as np
-import pytest
 from floris import FlorisModel
 from hercules.amr_wind_standin import AMRWindStandin
 from hercules.floris_standin import (

--- a/tests/floris_standin_test.py
+++ b/tests/floris_standin_test.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import logging
 import numpy as np
 import pytest
 from floris import FlorisModel
@@ -121,7 +122,7 @@ def test_FlorisStandin_get_step_yaw_angles():
         [260.0, 230.0]
     )
 
-def test_FlorisStandin_get_step_power_setpoints():
+def test_FlorisStandin_get_step_power_setpoints(caplog):
     floris_standin = FlorisStandin(CONFIG, AMR_INPUT, smoothing_coefficient=0.0)
 
     # Get FLORIS equivalent, match layout and turbines
@@ -155,10 +156,12 @@ def test_FlorisStandin_get_step_power_setpoints():
     fmodel_true_tp = fmodel_true.get_turbine_powers() / 1000
     assert np.allclose(fs_tp, fmodel_true_tp.flatten().tolist())
 
-    # Test with invalid combination of yaw angles and power setpoints
-    with pytest.raises(ValueError):
+    # Test warning raise with invalid combination of yaw angles and power setpoints
+    with caplog.at_level(logging.WARNING):
         floris_standin.get_step(5.0, yaw_angles=[230.0, 240.0], power_setpoints=[1e3, 1e3])
-    
+    assert caplog.text != "" # Checking not empty
+    caplog.clear()
+
     # Test with valid combination of yaw angles and power setpoints
     yaw_angles = [260.0, 240.0]
     power_setpoints = [None, 1e3]


### PR DESCRIPTION
@genevievestarke pointed out that an error can occur when using the `FlorisStandin` with a changing wind direction when performing active power control of the turbines. This occurs because the `FlorisStandin` turbines do not perfectly track the wind direction when it changes, which causes a yaw misalignment. FLORIS is not yet capable of simultaneously simulating a yaw misalignment and a demanded power from a turbine, so the simulation errors out. See #108.

The behavior is expected, and is actually tested [here](https://github.com/NREL/hercules/blob/develop/tests/floris_standin_test.py#L159-L160). However, to allow both a changing wind direction and active power control, this pull request ensures that, if a power setpoint is given to a specific turbine, it's yaw angle is set to zero to avoid raising the FLORIS error. 

This is not a perfect solution, because yawing is now possibly unrealistic. If, in future, we have a Floris turbine operation model that can handle [simultaneous yawing and derating](https://github.com/NREL/floris/issues/913), we will switch to that in the `FlorisStandin`.

@genevievestarke , you should now be able to run your example of the hybrid wind/solar/battery plant.

Paul: Added some additional changes in the course of debugging tests:

1. Removed unnecessary explicit install of FLORIS v4 in CI
2. Updated the call to ruff to follow new `ruff check` syntax
3. Added automatic testing of macos in addition to ubuntu-latest so in the future we will know if an issue is os-specific