### PR TITLE
Fix solar pysam bug for when an external signal is defined

### DIFF
--- a/hercules/python_simulators/solar_pysam.py
+++ b/hercules/python_simulators/solar_pysam.py
@@ -196,6 +196,8 @@ class SolarPySAM:
         elif "external_signals" in inputs.keys():
             if "solar_power_reference_mw" in inputs["external_signals"].keys():
                 P_setpoint = inputs["external_signals"]["solar_power_reference_mw"]
+            else:
+                P_setpoint = None
         else:
             P_setpoint = None
         self.control(P_setpoint)


### PR DESCRIPTION
Fixing a bug in pysam when an external signal is defined, but not a solar power reference set point.