### PR TITLE
[BUGFIX] Specify previous OS for ubuntu tests.

### DIFF
--- a/.github/workflows/check-working-examples.yaml
+++ b/.github/workflows/check-working-examples.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        os: [ubuntu-20.04] #, macos-latest, windows-latest]
       fail-fast: False
 
     steps:

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: False
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        os: [ubuntu-20.04] #, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
     - name: Generate coverage report
       # Run these tests on unit tests only so that we avoid inflating our code
       # coverage through the regression tests
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         pip install pytest
         pip install pytest-cov

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -10,7 +10,7 @@ on:
 # This job installs dependencies, builds the book, and pushes it to `gh-pages`
 jobs:
   deploy-book:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
After various debugging attempts, it seems that tests are failing only on `ubuntu-latest` (which is currently 22.04, see [here](https://github.com/actions/runner-images)). This pins the testing matrix back to the previous ubuntu OS, 20.04.