### PR TITLE
Provide options for grid charging and charging commands for batteries, electrolyzers

### DIFF
--- a/docs/battery.md
+++ b/docs/battery.md
@@ -11,6 +11,7 @@ Battery parameters are defined in the hercules input yaml file used to initializ
 - `charge_rate`: [kW]
 - `max_SOC`: between 0 and 1
 - `min_SOC`: between 0 and 1
+- `allow_grid_charging`: True or False (defaults to True)
 - `initial_conditions`
   - `SOC`: between `min_SOC` and `max_SOC`
 
@@ -22,7 +23,7 @@ Inputs are passed to `step()` as a dict named `inputs`, which must have the foll
 
 ```
 {py_sims:{inputs:{battery_signal: ____,
-                 available_power: ____
+                 locally_generated_power: ____
                  }}}
 ```
 

--- a/hercules/emulator.py
+++ b/hercules/emulator.py
@@ -239,7 +239,7 @@ class Emulator(FederateAgent):
 
         # Assign Py_sim outputs
         if self.main_dict["py_sims"]:
-            self.main_dict["py_sims"]["inputs"]["available_power"] += wind_farm_power
+            self.main_dict["py_sims"]["inputs"]["locally_generated_power"] += wind_farm_power
             # print("sim_time_s_amr_wind = ", sim_time_s_amr_wind)
             self.main_dict["py_sims"]["inputs"]["sim_time_s"] = sim_time_s_amr_wind
             # print('self.main_dict[''py_sims''][''inputs''][''sim_time_s''] = ',

--- a/hercules/py_sims.py
+++ b/hercules/py_sims.py
@@ -25,7 +25,7 @@ class PySims:
             print(self.py_sim_names)
             self.py_sim_dict["inputs"] = {}
             self.py_sim_dict["inputs"][
-                "available_power"
+                "locally_generated_power"
             ] = 0  # Always calculate available power for py_sims
 
             # Collect the py_sim objects, inputs and outputs
@@ -43,7 +43,7 @@ class PySims:
                         "object"
                     ].needed_inputs[needed_input]
             print(self.py_sim_dict["inputs"])
-            # TODO: always add 'available_power' as input??
+            # TODO: always add 'locally_generated_power' as input??
             # print(self.py_sim_dict['solar_farm_0']['object'])
 
     def get_py_sim(self, py_sim_obj_dict):
@@ -64,7 +64,7 @@ class PySims:
 
     def step(self, main_dict):
         # Collect the py_sim objects
-        py_sims_available_power = 0.0
+        locally_generated_power = 0.0
         for py_sim_name in self.py_sim_names:
             print(py_sim_name)
 
@@ -80,6 +80,6 @@ class PySims:
                     solar_power = self.py_sim_dict[py_sim_name]["outputs"]["power_mw"]*1000
                 except KeyError:
                     solar_power = self.py_sim_dict[py_sim_name]["outputs"]["power"]*1000
-                py_sims_available_power += solar_power
+                locally_generated_power += solar_power
 
-        self.py_sim_dict["inputs"]["available_power"] = py_sims_available_power
+        self.py_sim_dict["inputs"]["locally_generated_power"] = locally_generated_power

--- a/hercules/python_simulators/battery.py
+++ b/hercules/python_simulators/battery.py
@@ -79,6 +79,7 @@ class LIB:
             discharge_rate: discharge rate of the battery in MW
             max_SOC: upper boundary on battery SOC between 0 and 1
             min_SOC: lower boundary on battery SOC between 0 and 1
+            allow_grid_charging: boolean flag for allowing grid to charge the battery
             initial_conditions: {SOC: iniital SOC between 0 and 1}
         """
 
@@ -94,6 +95,12 @@ class LIB:
         self.SOC = inititial_conditions["SOC"]  # [fraction]
         self.SOC_max = input_dict["max_SOC"]
         self.SOC_min = input_dict["min_SOC"]
+
+        # Flag for allowing grid to charge the battery
+        if "allow_grid_charging" in input_dict.keys():
+            self.allow_grid_charging = input_dict["allow_grid_charging"]
+        else:
+            self.allow_grid_charging = True
 
         self.T = 25  # [C] temperature
         self.SOH = 1  # State of Health
@@ -243,14 +250,18 @@ class LIB:
         Inputs:
         - inputs: dictionary of inputs for the current time step which must have:
             - py_sims:{inputs:{battery_signal: ___ }} [kW] charging/discharging power desired
-            - py_sims:{inputs:{available_power: ___ }} [kW] power available for charging/discharging
+            - py_sims:{inputs:{locally_generated_power: ___ }} [kW] power available for
+                 charging/discharging that was generated onsite (not from grid)
 
         Outputs:
         - outptuts: see return_outputs() method
         """
 
         P_signal = inputs["py_sims"]["inputs"]["battery_signal"]  # [kW] requested power
-        P_avail = inputs["py_sims"]["inputs"]["available_power"]  # [kW] avaiable power
+        if self.allow_grid_charging:
+            P_avail = np.inf
+        else:
+            P_avail = inputs["py_sims"]["inputs"]["locally_generated_power"]  # [kW] available power
 
         # Calculate charging/discharging current [A] from power
         I_charge, I_reject = self.control(P_signal, P_avail)
@@ -400,6 +411,12 @@ class SimpleBattery:
         self.R_min = -np.inf
         self.R_max = np.inf
 
+        # Flag for allowing grid to charge the battery
+        if "allow_grid_charging" in input_dict.keys():
+            self.allow_grid_charging = input_dict["allow_grid_charging"]
+        else:
+            self.allow_grid_charging = True
+
         # Efficiency and self-discharge parameters
         if "roundtrip_efficiency" in input_dict.keys():
             self.eta_charge = np.sqrt(input_dict["roundtrip_efficiency"])
@@ -473,7 +490,10 @@ class SimpleBattery:
         # power available for the battery to use for charging (should be >=0)
         P_signal = inputs["py_sims"]["inputs"]["battery_signal"]
         # power signal desired by the controller
-        P_avail = inputs["py_sims"]["inputs"]["available_power"]
+        if self.allow_grid_charging:
+            P_avail = np.inf
+        else:
+            P_avail = inputs["py_sims"]["inputs"]["locally_generated_power"]  # [kW] available power
 
         P_charge, P_reject = self.control(P_avail, P_signal)
 

--- a/tests/python_simulators_test/battery_test.py
+++ b/tests/python_simulators_test/battery_test.py
@@ -14,6 +14,7 @@ def get_battery_params(battery_type):
         "max_SOC": 0.9,  # upper boundary on battery SOC
         "min_SOC": 0.1,  # lower boundary on battery SOC
         "initial_conditions": {"SOC": 0.102},
+        "allow_grid_charging": False,
     }
     dt = 1
     return battery_dict, dt
@@ -42,7 +43,7 @@ def LI():
 def step_inputs(P_avail, P_signal):
     return dict(
         {
-            "py_sims": {"inputs": {"available_power": P_avail, "battery_signal": P_signal}},
+            "py_sims": {"inputs": {"locally_generated_power": P_avail, "battery_signal": P_signal}},
         }
     )
 

--- a/tests/regression_tests/battery_regression_test.py
+++ b/tests/regression_tests/battery_regression_test.py
@@ -147,7 +147,7 @@ def test_SimpleBattery_regression_():
             "py_sims": {
                 "inputs": {
                     "battery_signal": powers_requested[i],
-                    "available_power": powers_requested[i]
+                    "locally_generated_power": powers_requested[i]
                 }
             }
         })
@@ -182,7 +182,7 @@ def test_LIB_regression_():
             "py_sims": {
                 "inputs": {
                     "battery_signal": powers_requested[i],
-                    "available_power": powers_requested[i]
+                    "locally_generated_power": powers_requested[i]
                 }
             }
         })
@@ -227,7 +227,7 @@ def test_SimpleBattery_usage_calc_regression():
     for i in range(len(power_avail)):
         step_input_dict = {
             "py_sims": {"inputs": {
-                "available_power": power_avail[i],
+                "locally_generated_power": power_avail[i],
                 "battery_signal": power_signal[i]
                 }
             },
@@ -256,7 +256,7 @@ def test_SimpleBattery_usage_calc_regression():
     for i in range(len(power_avail)):
         step_input_dict = {
             "py_sims": {"inputs": {
-                "available_power": power_avail[i],
+                "locally_generated_power": power_avail[i],
                 "battery_signal": 0
                 }
             },


### PR DESCRIPTION
Adds the following capabilities:
- Electrolyzer can charge following a commanded power consumption
- Electrolyzer and battery may charge from grid, if set up to do so

To do:
- [x] Implement main changes to source code
- [x] Check all existing tests pass/update tests so to test same functionality
- [ ] Add tests for new functionality
- [ ] Check all running examples still run and produce the same results