### PR TITLE
allow extrapolation in `find_time_utc_value`

### DIFF
--- a/hercules/utilities.py
+++ b/hercules/utilities.py
@@ -376,25 +376,50 @@ def _interpolate_with_polars(df, new_time, datetime_cols, numeric_cols):
 
 
 def find_time_utc_value(df, time_value, time_column="time", time_utc_column="time_utc"):
-    """Find the time_utc value.
+    """Return UTC timestamp at a given time value via linear interpolation or extrapolation.
 
-
+    This function maps a numeric simulation time to a UTC timestamp by linearly
+    interpolating between rows in ``df``. If ``time_value`` lies outside the
+    range of ``time_column``, linear extrapolation is performed.
 
     Args:
-        df (pd.DataFrame): DataFrame with time_column and time_utc_column.
-        time_value (float): Time value to find the time_utc value for.
-        time_column (str, optional): Name of the time column. Defaults to "time".
-        time_utc_column (str, optional): Name of the time_utc column. Defaults to "time_utc".
+        df (pd.DataFrame): Input DataFrame containing time and UTC columns.
+        time_value (float): Time at which to compute the UTC value.
+        time_column (str, optional): Name of the numeric time column. Defaults to "time".
+        time_utc_column (str, optional): Name of the UTC datetime column. Defaults to "time_utc".
 
     Returns:
-        datetime: Time_utc value.
+        pd.Timestamp: UTC-aware timestamp corresponding to ``time_value``.
     """
-    return (
-        df.set_index(time_column)[time_utc_column]
-        .interpolate(method="linear")
-        .reindex([time_value])
-        .iloc[0]
+    if time_column not in df.columns or time_utc_column not in df.columns:
+        raise ValueError(f"DataFrame must contain '{time_column}' and '{time_utc_column}' columns")
+
+    # Drop rows with missing values in either column, then sort by time
+    df_valid = (
+        df[[time_column, time_utc_column]]
+        .dropna(subset=[time_column, time_utc_column])
+        .sort_values(time_column)
     )
+
+    if len(df_valid) < 2:
+        raise ValueError("At least two valid rows are required for interpolation/extrapolation")
+
+    # Extract arrays for interpolation. Convert datetimes to seconds since epoch (UTC)
+    time_values = df_valid[time_column].to_numpy()
+    utc_ns = df_valid[time_utc_column].astype("int64").to_numpy()  # nanoseconds since epoch
+    utc_seconds = utc_ns.astype(np.float64) / 1e9
+
+    # Linear interpolation/extrapolation
+    f = interp1d(
+        time_values,
+        utc_seconds,
+        kind="linear",
+        bounds_error=False,
+        fill_value="extrapolate",
+        assume_sorted=True,
+    )
+    sec = float(f(time_value))
+    return pd.to_datetime(sec, unit="s", utc=True)
 
 
 def load_h_dict_from_text(filename):

--- a/tests/utilities_test.py
+++ b/tests/utilities_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from hercules.utilities import (
+    find_time_utc_value,
     interpolate_df,
     interpolate_df_fast,
     load_h_dict_from_text,
@@ -396,6 +397,67 @@ def test_interpolate_df_functions_identical_simple():
 
     # Verify results are identical
     pd.testing.assert_frame_equal(result_original, result_fast, check_dtype=False)
+
+
+# ==================== find_time_utc_value TESTS ====================
+
+
+def test_find_time_utc_interpolates_midpoint():
+    """Interpolates UTC between two points at the midpoint time."""
+    df = pd.DataFrame(
+        {
+            "time": [0.0, 10.0],
+            "time_utc": pd.to_datetime(
+                [
+                    "2023-01-01 00:00:00+00:00",
+                    "2023-01-01 00:00:10+00:00",
+                ],
+                utc=True,
+            ),
+        }
+    )
+
+    mid = find_time_utc_value(df, 5.0)
+    assert mid == pd.Timestamp("2023-01-01 00:00:05", tz="UTC")
+
+
+def test_find_time_utc_extrapolates_before_range():
+    """Extrapolates UTC for a time before the first sample."""
+    df = pd.DataFrame(
+        {
+            "time": [0.0, 10.0],
+            "time_utc": pd.to_datetime(
+                [
+                    "2023-01-01 00:00:00+00:00",
+                    "2023-01-01 00:00:10+00:00",
+                ],
+                utc=True,
+            ),
+        }
+    )
+
+    # 1 second per unit time -> time=-5 yields -5 seconds from start
+    t = find_time_utc_value(df, -5.0)
+    assert t == pd.Timestamp("2022-12-31 23:59:55", tz="UTC")
+
+
+def test_find_time_utc_extrapolates_after_range():
+    """Extrapolates UTC for a time after the last sample."""
+    df = pd.DataFrame(
+        {
+            "time": [0.0, 10.0],
+            "time_utc": pd.to_datetime(
+                [
+                    "2023-01-01 00:00:00+00:00",
+                    "2023-01-01 00:00:10+00:00",
+                ],
+                utc=True,
+            ),
+        }
+    )
+
+    t = find_time_utc_value(df, 15.0)
+    assert t == pd.Timestamp("2023-01-01 00:00:15", tz="UTC")
 
 
 def test_interpolate_df_functions_identical_with_datetime():


### PR DESCRIPTION
The function `find_time_utc_value` is used to identify UTC times that correspond to time values like 0, and start_time.  Currently, if the 0 time occurs outside the range of given UTC values, it returns `NaT`, however, it's possible to simply extrapolate to that time.  This PR fixes that and adds tests.