### PR TITLE
Fix deprecation and warning generating code

### DIFF
--- a/hercules/plant_components/solar_pysam_base.py
+++ b/hercules/plant_components/solar_pysam_base.py
@@ -84,7 +84,7 @@ class SolarPySAMBase(ComponentBase):
             df_solar["time_utc"] = pd.to_datetime(df_solar["time_utc"], format="ISO8601", utc=True)
 
         # Ensure time_utc is timezone-aware (UTC)
-        if not pd.api.types.is_datetime64tz_dtype(df_solar["time_utc"]):
+        if not isinstance(df_solar["time_utc"].dtype, pd.DatetimeTZDtype):
             df_solar["time_utc"] = df_solar["time_utc"].dt.tz_localize("UTC")
 
         # Get starttime_utc and endtime_utc from h_dict

--- a/hercules/plant_components/wind_meso_to_power.py
+++ b/hercules/plant_components/wind_meso_to_power.py
@@ -83,7 +83,7 @@ class Wind_MesoToPower(ComponentBase):
                 df_wi["time_utc"] = pd.to_datetime(df_wi["time_utc"], utc=True)
 
         # Ensure time_utc is timezone-aware (UTC)
-        if not pd.api.types.is_datetime64tz_dtype(df_wi["time_utc"]):
+        if not isinstance(df_wi["time_utc"].dtype, pd.DatetimeTZDtype):
             df_wi["time_utc"] = df_wi["time_utc"].dt.tz_localize("UTC")
 
         # Get starttime_utc and endtime_utc from h_dict

--- a/hercules/plant_components/wind_meso_to_power_precom_floris.py
+++ b/hercules/plant_components/wind_meso_to_power_precom_floris.py
@@ -121,7 +121,7 @@ class Wind_MesoToPowerPrecomFloris(ComponentBase):
                 df_wi["time_utc"] = pd.to_datetime(df_wi["time_utc"], utc=True)
 
         # Ensure time_utc is timezone-aware (UTC)
-        if not pd.api.types.is_datetime64tz_dtype(df_wi["time_utc"]):
+        if not isinstance(df_wi["time_utc"].dtype, pd.DatetimeTZDtype):
             df_wi["time_utc"] = df_wi["time_utc"].dt.tz_localize("UTC")
 
         # Get starttime_utc and endtime_utc from h_dict

--- a/tests/grid_utilities_test.py
+++ b/tests/grid_utilities_test.py
@@ -63,7 +63,7 @@ def test_generate_locational_marginal_price_dataframe_from_gridstatus():
     assert df_out_2.equals(df_out)
 
     # Check that error is raised if markets are not all consistent
-    df_da_diff_market["market"].iloc[0] = "ANOTHER_MARKET"
+    df_da_diff_market.loc[df_da_diff_market.index[0], "market"] = "ANOTHER_MARKET"
     with pytest.raises(ValueError):
         generate_locational_marginal_price_dataframe_from_gridstatus(
             df_da_diff_market,


### PR DESCRIPTION
This pull request makes minor improvements to how timezone-aware datetime columns are detected and localized in several plant component modules, and also updates a test to use a more robust pandas indexing method.

These lines had been generating deprecation warnings in the first case, and chained copy warnings in latter.