### PR TITLE
Update URLs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,6 +6,6 @@ authors:
     given-names:
 title: "HERCULES"
 version: 2
-url: https://github.com/NREL/hercules
+url: https://github.com/NatLabRockies/hercules
 
 date-released: 2025-12-31

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Hercules is an open-source tool for hybrid plant simulation in real time. Hercul
 
 ## Part of the WETO Stack
 
-Hercules is primarily developed with the support of the U.S. Department of Energy and is part of the [WETO Software Stack](https://nrel.github.io/WETOStack). For more information and other integrated modeling software, see:
-- [Portfolio Overview](https://nrel.github.io/WETOStack/portfolio_analysis/overview.html)
-- [Entry Guide](https://nrel.github.io/WETOStack/_static/entry_guide/index.html)
-- [High-Fidelity Modeling Workshop](https://nrel.github.io/WETOStack/workshops/user_workshops_2024.html#high-fidelity-modeling)
+Hercules is primarily developed with the support of the U.S. Department of Energy and is part of the [WETO Software Stack](https://natlabrockies.github.io/WETOStack). For more information and other integrated modeling software, see:
+- [Portfolio Overview](https://natlabrockies.github.io/WETOStack/portfolio_analysis/overview.html)
+- [Entry Guide](https://natlabrockies.github.io/WETOStack/_static/entry_guide/index.html)
+- [High-Fidelity Modeling Workshop](https://natlabrockies.github.io/WETOStack/workshops/user_workshops_2024.html#high-fidelity-modeling)
 
 # Documentation
 
-For detailed instructions see the [online documentation](https://nrel.github.io/hercules/)
+For detailed instructions see the [online documentation](https://natlabrockies.github.io/hercules/)
 
 # Installation
 
-For installation instructions see: [installation instructions](https://nrel.github.io/hercules/install.html)
+For installation instructions see: [installation instructions](https://natlabrockies.github.io/hercules/install.html)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,7 +25,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/NREL/hercules
+  url: https://github.com/NatLabRockies/hercules
   path_to_book: docs
   branch: develop
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ cd hercules_root
 ## Clone Hercules
 
 ```bash
-git clone https://github.com/NREL/hercules
+git clone https://github.com/NatLabRockies/hercules
 cd hercules
 ```
 

--- a/docs/not_used/install_on_kestrel.md
+++ b/docs/not_used/install_on_kestrel.md
@@ -70,7 +70,7 @@ pip install -e SEAS
 Go back to herc_root
 
 ```
-git clone https://github.com/NREL/hercules
+git clone https://github.com/NatLabRockies/hercules
 pip install -e hercules
 ```
 

--- a/examples/grid/grid_status_download_example.py
+++ b/examples/grid/grid_status_download_example.py
@@ -2,9 +2,9 @@
 # Download 2 days of data for the OKGE.FRONTIER location
 # Download both real time and day ahead data
 # See the documentation for more details of this example:
-# https://nrel.github.io/hercules/gridstatus_download.html
+# https://natlabrockies.github.io/hercules/gridstatus_download.html
 # Note api key is required, see the documentation for more details:
-# https://nrel.github.io/hercules/gridstatus_download.html#api-key-setup
+# https://natlabrockies.github.io/hercules/gridstatus_download.html#api-key-setup
 
 # Run using uvx --with gridstatusio --with pyarrow python grid_status_download_example.py
 

--- a/examples/grid/process_grid_status_data.py
+++ b/examples/grid/process_grid_status_data.py
@@ -3,7 +3,7 @@
 # The output dataframe is formatted for use as external data in Hercules and includes convenient
 # forward hours of day ahead for certain Hycon applications.
 # See the documentation for more details of this example:
-# https://nrel.github.io/hercules/gridstatus_download.html#combining-real-time-and-day-ahead-data-for-hycon
+# https://natlabrockies.github.io/hercules/gridstatus_download.html#combining-real-time-and-day-ahead-data-for-hycon
 
 import pandas as pd
 from hercules.grid.grid_utilities import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     { name = "Brooke Stanislawski", email = "Brooke.Stanislawski@nrel.gov" },
 ]
 license = { file = "LICENSE.txt" }
-urls = { "Homepage" = "https://github.com/NREL/hercules" }
+urls = { "Homepage" = "https://github.com/NatLabRockies/hercules" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Update URLS: 
- github.com/NREL/ -> github.com/NatLabRockies/
- nrel.github.io -> natlabrockies.github.io

Prior to merger, check final location of WETOSoftware documentation page

@genevievestarke : Would you rather merge this straight into main without a new release (and then merge back into develop), or would you prefer to merge into develop and then create a patch release to get it onto main? I'm planning on the latter for FLORIS, but doing it slightly more informally on Hercules is probably fine if you'd rather not jump through the hoops of releasing Hercules at the moment.

This PR should _not_ be merged until the organization name actually changes to github.com/NatLabRockies