### PR TITLE
[BUGFIX] Remove bad copies in docs build procedure

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -24,33 +24,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e ".[docs]"
-    
-    - name: Make copies of example docs
-      run: |
-        mkdir -vp docs/examples
-
-        cp -v examples/00_wind_farm_only/README.md docs/examples/00_wind_farm_only.md
-        cp -v examples/01_wind_farm_dof1_model/README.md docs/examples/01_wind_farm_dof1_model.md
-        cp -v examples/02_wind_farm_realistic_inflow/README.md docs/examples/02_wind_farm_realistic_inflow.md
-        cp -v examples/02b_wind_farm_realistic_inflow_precom_floris/README.md docs/examples/02b_wind_farm_realistic_inflow_precom_floris.md
-        cp -v examples/03_wind_and_solar/README.md docs/examples/03_wind_and_solar.md
-        cp -v examples/04_wind_and_storage/README.md docs/examples/04_wind_and_storage.md
-        ls -l docs/examples
-
-    - name: Debug directory structure
-      run: |
-        echo "Current directory: $(pwd)"
-        echo "GitHub workspace: ${{github.workspace}}"
-        echo "Runner workspace: ${{runner.workspace}}"
-        ls -la
-        ls -la docs/
-        ls -la docs/examples/
-
-    # # Build the book
-    # - name: Build the book
-    #   working-directory: ${{runner.workspace}}/hercules/docs/
-    #   run: |
-    #     jupyter-book build .
 
     # Build the book
     - name: Build the book


### PR DESCRIPTION
PR #201 cleaned up the docs/examples and consolidated documentation of the examples into docs/examples and removed the README files within each folder (following the approach in Hycon).  The deploy-pages CI should have been updated to no longer copy those READMEs in the doc structure as we had done before (see failed action [here](https://github.com/NatLabRockies/hercules/actions/runs/21682602813)).

This PR fixes that by removing code to copy readmes that are no longer in the examples.

It also removes some no longer needed debug code and commented out code