### PR TITLE
Update python versions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [ "3.11", "3.12", "3.13"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
 
     steps:

--- a/hercules/hercules_model.py
+++ b/hercules/hercules_model.py
@@ -488,7 +488,6 @@ class HerculesModel:
             external_signals_all = self.external_signals_all
             h_dict = self.h_dict
 
-
             # Set current time and run simulation through steps
             self.time = self.starttime
             last_progress_update = 0

--- a/hercules/hercules_model.py
+++ b/hercules/hercules_model.py
@@ -488,6 +488,7 @@ class HerculesModel:
             external_signals_all = self.external_signals_all
             h_dict = self.h_dict
 
+
             # Set current time and run simulation through steps
             self.time = self.starttime
             last_progress_update = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "hercules"
 version = "2"
 description = "Hybrid plant emulation tool."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
      { name = "Genevieve Starke", email = "Genevieve.Starke@nlr.gov" },
     { name = "Michael (Misha) Sinner", email = "Michael.Sinner@nlr.gov" },


### PR DESCRIPTION
Currently in Hercules the minimum python version is specified as 3.9, and then in CI we test 3.9, 3.10 and 3.11.  This PR makes a few small changes:

1) Updates minimum version to 3.10
2) Drops CI testing of 3.9 and adds testing of 3.12 and 3.13

The reasons for (1) are:
1) Numpy 2.1+ no longer supports 3.9 and Hercules has a ~2.0 dependency to numpy which would include 2.1
2) Python 3.9 is end of life: https://devguide.python.org/versions/

The reasons for (2) are that we were implicitly supporting these versions without testing