### PR TITLE
[DOCS] Update installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -36,7 +36,7 @@ conda activate hercules
 Alternatively, you can use uv to create a new environment for hercules.  This will create a new environment in the current directory.
 
 ```bash
-uv venv
+uv venv --python 3.13
 source .venv/bin/activate
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,11 +23,11 @@ cd hercules
 
 It is recommended that you install Hercules into a virtual environment.
 
-### CONDA
+### Conda
 
 To create a new conda environment for hercules:
 ```bash
-conda create --name hercules python=3.11
+conda create --name hercules python=3.13
 conda activate hercules
 ```
 
@@ -54,7 +54,7 @@ Install Hercules in editible mode into the active virtual environment.
 pip install -e .
 ```
 
-### With Developer and Documentation Dependencies
+### With developer and documentation Dependencies
 
 ```bash
 pip install -e .[develop,docs]
@@ -62,11 +62,11 @@ pip install -e .[develop,docs]
 
 ## Setting branch
 
-Can optionally switch to the v2 branch for the latest stable version.
+Users can simply remain on the `main` branch. Developers should switch to the `develop` branch to get the latest code changes. To change to the `develop` branch, use
 
 ```bash
 git fetch --all
-git switch v2
+git switch develop
 ```
 
 ## Hycon
@@ -75,10 +75,9 @@ NLR's Hycon software is used to implement controllers in the Hercules platform. 
 
 
 To install:
-Go back to root
 
 ```bash
-cd ..
+cd .. # To hercules_root
 git clone git@github.com:NREL/hycon.git
 cd hycon
 git fetch --all
@@ -91,9 +90,7 @@ A python electrolyzer model is also required for hercules. To install
 the electrolyzer, use
 
 ```bash
-cd ..
+cd .. # To hercules_root
 git clone git@github.com:NREL/electrolyzer.git
-cd electrolyzer
-git fetch --all
-git switch main
+pip install electrolyzer/
 ```


### PR DESCRIPTION
The [existing installation instructions](https://natlabrockies.github.io/hercules/install.html) incorrectly refer to `git switch`ing to the `v2` branch. That branch no longer exists, and moreover, `v2` is a tag that can't be `switch`ed to but can be `checkout`ed, which creates confusion.

This PR updates the installation instructions. In doing so, I also added a missing `pip install` command for the electrolyzer repo and clarified that `develop` need only be switched to if the user plans to actually perform code development.

Thanks @jfrederik-nrel for identifying this issue!