### PR TITLE
PyPI publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,34 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# Published via GitHub Actions as a PyPI Trusted Publisher.
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# and: https://docs.pypi.org/trusted-publishers/
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    environment: release-pypi
+    if: github.repository_owner == 'NatLabRockies'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install dependencies and build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: True


### PR DESCRIPTION
Adds a workflow to publish Hercules as a package on PyPI. Hercules would first appear on PyPI after this pull request arrives on the main branch and a new release for Hercules is created.

Set up using PyPI's Trusted Publishing workflow.

Unforunately, [`hercules`](https://pypi.org/project/hercules/) is taken as a PyPI package name (on 0.0, with no releases since 2014.... oh well). We could alternatively publish under the following, which appear to be available:
- [`herc`](https://pypi.org/project/herc/) 
- [`nlr-hercules`](https://pypi.org/project/nlr-hercules/)

Any other suggestions?