### PR TITLE
Enable compatibility with `NREL-PySAM` v6 and v7

### DIFF
--- a/hercules/plant_components/solar_pysam_pvwatts.py
+++ b/hercules/plant_components/solar_pysam_pvwatts.py
@@ -68,10 +68,6 @@ class SolarPySAMPVWatts(SolarPySAMBase):
         system_model.assign(self.model_params)
 
         system_model.AdjustmentFactors.adjust_constant = 0
-        try:
-            system_model.AdjustmentFactors.dc_adjust_constant = 0
-        except Exception:
-            pass
 
         # Save the system model
         self.system_model = system_model
@@ -98,10 +94,6 @@ class SolarPySAMPVWatts(SolarPySAMBase):
 
         # Assign the full solar resource data
         self.system_model.SolarResource.assign({"solar_resource_data": solar_resource_data})
-        try:
-            self.system_model.AdjustmentFactors.assign({"constant": 0})
-        except Exception:
-            pass
 
         # Execute the model once for all time steps
         self.system_model.execute()

--- a/hercules/plant_components/solar_pysam_pvwatts.py
+++ b/hercules/plant_components/solar_pysam_pvwatts.py
@@ -68,7 +68,10 @@ class SolarPySAMPVWatts(SolarPySAMBase):
         system_model.assign(self.model_params)
 
         system_model.AdjustmentFactors.adjust_constant = 0
-        system_model.AdjustmentFactors.dc_adjust_constant = 0
+        try:
+            system_model.AdjustmentFactors.dc_adjust_constant = 0
+        except Exception:
+            pass
 
         # Save the system model
         self.system_model = system_model
@@ -95,7 +98,10 @@ class SolarPySAMPVWatts(SolarPySAMBase):
 
         # Assign the full solar resource data
         self.system_model.SolarResource.assign({"solar_resource_data": solar_resource_data})
-        self.system_model.AdjustmentFactors.assign({"constant": 0})
+        try:
+            self.system_model.AdjustmentFactors.assign({"constant": 0})
+        except Exception:
+            pass
 
         # Execute the model once for all time steps
         self.system_model.execute()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 "matplotlib~=3.8",
 "pandas~=2.0",
 "floris~=4.3",
-"nrel-pysam~=6.0",
+"nrel-pysam>=6,<8",
 "jupyter",
 "netCDF4",
 "rainflow~=3.2",


### PR DESCRIPTION
Currently, Hercules [requires `NREL-PySAM v6`](https://github.com/NatLabRockies/hercules/blob/efb5fd666d7f1b66329177abe779c00c993ec7df/pyproject.toml#L32). However, [v7 was released in April 2025](https://github.com/NatLabRockies/pysam/releases/tag/v7.0.0) and the [latest version is v7.1.0](https://github.com/NatLabRockies/pysam/releases/tag/v7.1.0) (released August 2025).

Hercules, as is, is not compatible with v7 of `NREL-PySAM`. This "fixes" this by adding a couple of `try`/`except` clauses on a few lines that generate errors. *However, I am not sure if this is a legitimate fix or if I am changing the behavior*.

With the update:
- tests pass using both v6.0.1 and v7.1.0
- example 03_wind_and_solar runs to completion and produces visually the same result:

Using v6.0.1:
<img width="468" height="342" alt="image" src="https://github.com/user-attachments/assets/dbd8819b-be6c-4578-b3ab-2f74fe038513" />

Using v7.1.0:
<img width="468" height="343" alt="image" src="https://github.com/user-attachments/assets/df6e2f50-7e4c-4b5a-aee1-414a6aaa5789" />


Assuming we no longer need to use the lines that are `except`ed in this change, we could simply require v7. However, this is a change that will affect users directly, as they'll need to update their local environments to keep using Hercules. The change I've implemented here allows users to stay on v6, or to move up to v7.

*If a valid correction*, addresses #218 
