### PR TITLE
Update electrolyzer as a dependency

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -22,8 +22,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[develop]"
-        pip install git+https://github.com/NREL/electrolyzer.git
-        pip install https://github.com/NREL/SEAS/blob/v1/SEAS.tar.gz?raw=true
 #    - uses: pre-commit/action@v3.0.0
     - name: Run ruff
       run: |
@@ -42,11 +40,10 @@ jobs:
         pip install pytest
         pip install pytest-cov
         pytest --cov=./ --cov-report=xml tests/
-    - name: Upload coverage to Codecov  
+    - name: Upload coverage to Codecov
       if: ${{ env.CODECOV_TOKEN }}  # Don't attempt to upload if the codecov token is not configured
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml
         fail_ci_if_error: true
-        

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@
 
 ## Root Directory
 
-It is recommended to install Hercules into a root directory.  This root directory can also contain other projects that are often used with Hercules such as Hycon and the Electrolyzer.
+It is recommended to install Hercules into a root directory.  This root directory can also contain other projects that are often used with Hercules such as Hycon.
 
 ```bash
 mkdir -p hercules_root
@@ -82,15 +82,4 @@ git clone git@github.com:NREL/hycon.git
 cd hycon
 git fetch --all
 pip install -e .
-```
-
-## Electrolyzer
-
-A python electrolyzer model is also required for hercules. To install
-the electrolyzer, use
-
-```bash
-cd .. # To hercules_root
-git clone git@github.com:NREL/electrolyzer.git
-pip install electrolyzer/
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
 "cartopy",
 "openmeteo_requests",
 "requests_cache",
-"retry_requests"
+"retry_requests",
+"electrolyzer"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The electrolyzer can now be pip installed as a package! This updates the Hercules dependencies and the documentation.

- [x] Check continuous integration script to use pip install
- [x] Delete SEAS from CI workflow
