### PR TITLE
Fill NaN values in WindFarmSCADAPower

### DIFF
--- a/hercules/plant_components/wind_farm_scada_power.py
+++ b/hercules/plant_components/wind_farm_scada_power.py
@@ -130,7 +130,9 @@ class WindFarmSCADAPower(ComponentBase):
         self.logger.info(f"Inferred number of turbines: {self.n_turbines}")
 
         # Collect the turbine powers
-        self.scada_powers = df_scada[self.power_columns].to_numpy(dtype=hercules_float_type)
+        self.scada_powers = (
+            df_scada[self.power_columns].fillna(0.0).to_numpy(dtype=hercules_float_type)
+        )
 
         # Now get the wind speed and directions
 


### PR DESCRIPTION
The `WindFarmSCADAPower` is meant to playback pre-recorded turbine power without control.  Full power is computed via 

```
h_dict[self.component_name]["power"] = np.sum(self.turbine_powers)
```

Which, if any of the elements of`self.turbine_powers` is `np.nan` evaluates to `np.nan`.  This PR resolves this by assuming any turbine powers which are `np.nan` in the provided data are 0.0.  (An alternative solution would be to use `np.nansum` here and in `get_initial_conditions_and_meta_data`

Possible also you will prefer this operation be standalone and not chained.  Confirmed in one project this resolves the issue at least.