### PR TITLE
Add initial coal plant model

### DIFF
--- a/docs/hard_coal_steam_turbine.md
+++ b/docs/hard_coal_steam_turbine.md
@@ -1,0 +1,155 @@
+# Hard Coal Steam Turbine
+
+The `HardCoalSteamTurbine` (HCST) class models a hard coal power production plant using steam turbines. This class is a subclass of {doc}`ThermalComponentBase <thermal_component_base>` and inherits all state machine behavior, ramp constraints, and operational logic from the base class.
+
+Set `component_type: HardCoalSteamTurbine` in the component's YAML section. The section key is a user-chosen `component_name` (e.g. `hard_coal_steam_turbine`); see [Component Names, Types, and Categories](component_types.md) for details.
+
+For details on the state machine, startup/shutdown behavior, and base parameters, see {doc}`thermal_component_base`.
+
+## HCST-Specific Parameters
+
+The HCST class provides default values for bituminous coal properties from [4]:
+
+| Parameter | Units | Default | Description |
+|-----------|-------|---------|-------------|
+| `hhv` | J/m³ | 29310000000 | Higher heating value of bituminous coal (29.31 MJ/kg) [4] |
+| `fuel_density` | kg/m³ | 1000 | Fuel density for mass calculations |
+
+The `efficiency_table` parameter is **optional**. If not provided, default values based on approximate readings from the [2] are used. All efficiency values are **HHV (Higher Heating Value) net plant efficiencies**. See {doc}`thermal_component_base` for details on the efficiency table format.
+
+## Default Parameter Values
+
+The `HardCoalSteamTurbine` class provides default values for base class parameters based on References [1-4]. Only `rated_capacity` and `initial_conditions` are required in the YAML configuration.
+
+| Parameter | Default Value | Source |
+|-----------|---------------|--------|
+| `min_stable_load_fraction` | 0.30 (30%) | [2] |
+| `ramp_rate_fraction` | 0.03 (3%/min) | [1] |
+| `run_up_rate_fraction` | Same as `ramp_rate_fraction` | — |
+| `hot_startup_time` | 7.5 hours | [1] |
+| `warm_startup_time` | 7.5 hours | [1] |
+| `cold_startup_time` | 7.5 hours | [1] |
+| `min_up_time` | 48 hours | [2] |
+| `min_down_time` | 48 hours | [2] |
+| `efficiency_table` | Average plant efficiency | [2,3] |
+
+### Default Efficiency Table
+
+The default HHV net plant efficiency table is based on [2,3]:
+
+| Power Fraction | HHV Net Efficiency |
+|---------------|-------------------|
+| 1.00 | 0.35 (35%) |
+| 0.5o | 0.32 (32%) |
+| 0.30 | 0.30 (30%) |
+
+## HCST Outputs
+
+The HCST model provides the following outputs (inherited from base class):
+
+| Output | Units | Description |
+|--------|-------|-------------|
+| `power` | kW | Actual power output |
+| `state` | integer | Operating state number (0-5), corresponding to the `STATES` enum |
+| `efficiency` | fraction (0-1) | Current HHV net plant efficiency |
+| `fuel_volume_rate` | m³/s | Fuel volume flow rate |
+| `fuel_mass_rate` | kg/s | Fuel mass flow rate (computed using `fuel_density` |
+
+### Efficiency and Fuel Rate
+
+HHV net plant efficiency varies with load based on the `efficiency_table`. The fuel volume rate is calculated as:
+
+$$
+\text{fuel\_volume\_rate} = \frac{\text{power}}{\text{efficiency} \times \text{hhv}}
+$$
+
+Where:
+- `power` is in W (converted from kW internally)
+- `efficiency` is the HHV net efficiency interpolated from the efficiency table
+- `hhv` is the higher heating value in J/m³ (default 39.05 MJ/m³ for bituminous coal [4])
+- Result is fuel volume rate in m³/s
+
+The fuel mass rate is then computed from the volume rate using the fuel density:
+
+$$
+\text{fuel\_mass\_rate} = \text{fuel\_volume\_rate} \times \text{fuel\_density}
+$$
+
+Where:
+- `fuel_volume_rate` is in m³/s
+- `fuel_density` is in kg/m³ (default 1000 kg/m³ for bituminous coal)
+- Result is fuel mass rate in kg/s
+
+## YAML Configuration
+
+### Minimal Configuration
+
+Required parameters only (uses defaults for `hhv`, `efficiency_table`, and other parameters):
+
+```yaml
+hard_coal_steam_turbine:
+  component_type: HardCoalSteamTurbine
+  rated_capacity: 100000  # kW (100 MW)
+  initial_conditions:
+    power: 0  # 0 kW means OFF; power > 0 means ON
+```
+
+### Full Configuration
+
+All parameters explicitly specified:
+
+```yaml
+hard_coal_steam_turbine:
+  component_type: HardCoalSteamTurbine
+  rated_capacity: 500000  # kW (500 MW)
+  min_stable_load_fraction: 0.3  # 30% minimum operating point
+  ramp_rate_fraction: 0.03  # 3%/min ramp rate
+  run_up_rate_fraction: 0.02  # 2%/min run up rate
+  hot_startup_time: 27000.0  # 7.5 hours
+  warm_startup_time: 27000.0  # 7.5 hours
+  cold_startup_time: 27000.0  # 7.5 hours
+  min_up_time: 172800  # 48 hours
+  min_down_time: 172800  # 48 hour
+  hhv: 29310000000  # J/m³ for bituminous coal (29.31 MJ/m³) [4]
+  fuel_density: 1000  # kg/m³ for bituminous coal
+  efficiency_table:
+    power_fraction:
+      - 1.0
+      - 0.50
+      - 0.30
+    efficiency:  # HHV net plant efficiency, fractions (0-1)
+      - 0.35
+      - 0.32
+      - 0.32
+  log_channels:
+    - power
+    - fuel_volume_rate
+    - fuel_mass_rate
+    - state
+    - efficiency
+    - power_setpoint
+  initial_conditions:
+    power: 0  # 0 kW means OFF; power > 0 means ON
+```
+
+## Logging Configuration
+
+The `log_channels` parameter controls which outputs are written to the HDF5 output file.
+
+**Available Channels:**
+- `power`: Actual power output in kW (always logged)
+- `state`: Operating state number (0-5), corresponding to the `STATES` enum
+- `fuel_volume_rate`: Fuel volume flow rate in m³/s
+- `fuel_mass_rate`: Fuel mass flow rate in kg/s
+- `efficiency`: Current HHV net plant efficiency (0-1)
+- `power_setpoint`: Requested power setpoint in kW
+
+## References
+
+1. Agora Energiewende (2017): "Flexibility in thermal power plants - With a focus on existing coal-fired power plants."
+
+2. IRENA (2019), Innovation landscape brief: Flexibility in conventional power plants, International Renewable Energy Agency, Abu Dhabi.
+
+3. T. Schmitt, S. Leptinsky, M. Turner, A. Zoelle, C. White, S. Hughes, S. Homsy, et al. “Cost And Performance Baseline for Fossil Energy Plants Volume 1: Bituminous Coal and Natural Gas Electricity.” Pittsburgh, PA: National Energy Technology Laboratory, October 14, 2022b. https://doi.org/10.2172/1893822.
+
+4. I. Staffell, "The Energy and Fuel Data Sheet," University of Birmingham, March 2011. https://claverton-energy.com/cms4/wp-content/uploads/2012/08/the_energy_and_fuel_data_sheet.pdf

--- a/docs/hard_coal_steam_turbine.md
+++ b/docs/hard_coal_steam_turbine.md
@@ -66,7 +66,7 @@ $$
 Where:
 - `power` is in W (converted from kW internally)
 - `efficiency` is the HHV net efficiency interpolated from the efficiency table
-- `hhv` is the higher heating value in J/m³ (default 39.05 MJ/m³ for bituminous coal [4])
+- `hhv` is the higher heating value in J/m³
 - Result is fuel volume rate in m³/s
 
 The fuel mass rate is then computed from the volume rate using the fuel density:
@@ -77,7 +77,7 @@ $$
 
 Where:
 - `fuel_volume_rate` is in m³/s
-- `fuel_density` is in kg/m³ (default 1000 kg/m³ for bituminous coal)
+- `fuel_density` is in kg/m³
 - Result is fuel mass rate in kg/s
 
 ## YAML Configuration

--- a/examples/08_hard_coal_steam_turbine/hercules_input.yaml
+++ b/examples/08_hard_coal_steam_turbine/hercules_input.yaml
@@ -28,19 +28,15 @@ hard_coal_steam_turbine:
   cold_startup_time: 27000.0  # 7.5 hours
   min_up_time: 172800  # 48 hours
   min_down_time: 172800  # 48 hour
-  # Natural gas properties from [6] Staffell, "The Energy and Fuel Data Sheet", 2011
-  # HHV: 39.05 MJ/m³, Density: 0.768 kg/m³
-  # hhv: 39050000  # J/m³ for natural gas (39.05 MJ/m³) [6]
-  # fuel_density: 0.768  # kg/m³ for natural gas [6]
-  # efficiency_table:
-  power_fraction:
-    - 1.0
-    - 0.50
-    - 0.30
-  efficiency:  # HHV net plant efficiency, fractions (0-1)
-    - 0.35
-    - 0.32
-    - 0.32
+  efficiency_table:
+    power_fraction:
+      - 1.0
+      - 0.50
+      - 0.30
+    efficiency:  # HHV net plant efficiency, fractions (0-1)
+      - 0.35
+      - 0.32
+      - 0.32
   log_channels:
     - power
     - fuel_volume_rate
@@ -49,6 +45,6 @@ hard_coal_steam_turbine:
     - efficiency
     - power_setpoint
   initial_conditions:
-    power: 500000  # Start ON at rated capacity (500 MW)
+    power: 500000  # Start ON at rated capacity
 
 controller:

--- a/examples/08_hard_coal_steam_turbine/hercules_input.yaml
+++ b/examples/08_hard_coal_steam_turbine/hercules_input.yaml
@@ -10,7 +10,7 @@ description: Hard Coal Steam Turbine (HCST) Example
 
 dt: 60.0  # 1 minute time step
 starttime_utc: "2020-01-01T00:00:00Z"  # Midnight Jan 1, 2020 UTC
-endtime_utc: "2020-01-10T00:00:00Z"  # 6 hours later
+endtime_utc: "2020-01-10T00:00:00Z"  # 10 days later
 verbose: False
 log_every_n: 1
 
@@ -26,8 +26,8 @@ hard_coal_steam_turbine:
   hot_startup_time: 27000.0  # 7.5 hours
   warm_startup_time: 27000.0  # 7.5 hours
   cold_startup_time: 27000.0  # 7.5 hours
-  min_up_time: 172800  # 24 hours
-  min_down_time: 172800  # 24 hour
+  min_up_time: 172800  # 48 hours
+  min_down_time: 172800  # 48 hour
   # Natural gas properties from [6] Staffell, "The Energy and Fuel Data Sheet", 2011
   # HHV: 39.05 MJ/m³, Density: 0.768 kg/m³
   # hhv: 39050000  # J/m³ for natural gas (39.05 MJ/m³) [6]

--- a/examples/08_hard_coal_steam_turbine/hercules_input.yaml
+++ b/examples/08_hard_coal_steam_turbine/hercules_input.yaml
@@ -1,0 +1,54 @@
+# Input YAML for hercules
+# Explicitly specify the parameters for demonstration purposes
+
+# Name
+name: example_08
+
+###
+# Describe this simulation setup
+description: Hard Coal Steam Turbine (HCST) Example
+
+dt: 60.0  # 1 minute time step
+starttime_utc: "2020-01-01T00:00:00Z"  # Midnight Jan 1, 2020 UTC
+endtime_utc: "2020-01-10T00:00:00Z"  # 6 hours later
+verbose: False
+log_every_n: 1
+
+plant:
+  interconnect_limit: 500000  # kW (500 MW)
+
+hard_coal_steam_turbine:
+  component_type: HardCoalSteamTurbine
+  rated_capacity: 500000  # kW (500 MW)
+  min_stable_load_fraction: 0.3  # 30% minimum operating point
+  ramp_rate_fraction: 0.03  # 3%/min ramp rate
+  run_up_rate_fraction: 0.02  # 2%/min run up rate
+  hot_startup_time: 27000.0  # 7.5 hours
+  warm_startup_time: 27000.0  # 7.5 hours
+  cold_startup_time: 27000.0  # 7.5 hours
+  min_up_time: 172800  # 24 hours
+  min_down_time: 172800  # 24 hour
+  # Natural gas properties from [6] Staffell, "The Energy and Fuel Data Sheet", 2011
+  # HHV: 39.05 MJ/m³, Density: 0.768 kg/m³
+  # hhv: 39050000  # J/m³ for natural gas (39.05 MJ/m³) [6]
+  # fuel_density: 0.768  # kg/m³ for natural gas [6]
+  # efficiency_table:
+  power_fraction:
+    - 1.0
+    - 0.50
+    - 0.30
+  efficiency:  # HHV net plant efficiency, fractions (0-1)
+    - 0.35
+    - 0.32
+    - 0.32
+  log_channels:
+    - power
+    - fuel_volume_rate
+    - fuel_mass_rate
+    - state
+    - efficiency
+    - power_setpoint
+  initial_conditions:
+    power: 500000  # Start ON at rated capacity (500 MW)
+
+controller:

--- a/examples/08_hard_coal_steam_turbine/hercules_runscript.py
+++ b/examples/08_hard_coal_steam_turbine/hercules_runscript.py
@@ -1,4 +1,4 @@
-"""Example 07: Hard Coal Steam Turbine (HCST) simulation.
+"""Example 08: Hard Coal Steam Turbine (HCST) simulation.
 
 This example demonstrates a simple hard coal steam turbine (HCST) that:
 - Starts on at rated capacity

--- a/examples/08_hard_coal_steam_turbine/hercules_runscript.py
+++ b/examples/08_hard_coal_steam_turbine/hercules_runscript.py
@@ -36,11 +36,15 @@ class ControllerHCST:
         """
         self.component_name = component_name
         self.rated_capacity = h_dict[self.component_name]["rated_capacity"]
-        # Controller operates in 1-minute intervals, so base unit is an hour
-        self.controller_base_unit = 45
+
+        simulation_length = h_dict["endtime_utc"] - h_dict["starttime_utc"]
+        self.total_simulation_time = simulation_length.total_seconds()
 
     def step(self, h_dict):
         """Execute one control step.
+        This controller is scaled by the total simulation time, pulled from the h_dict
+        This preserves the relative distance between control actions, but changes the
+            simulation times that they are applied.
 
         Args:
             h_dict (dict): The hercules input dictionary.
@@ -51,28 +55,27 @@ class ControllerHCST:
         """
         current_time = h_dict["time"]
 
-        # NOTE: update doc strings to reflect base unit scaling
         # Determine power setpoint based on time
-        if current_time < 10 * self.controller_base_unit * 60:  # 10 minutes in seconds
-            # Before 10 minutes: run at full capacity
+        if current_time < 0.05 * self.total_simulation_time:
+            # First 5% of simulation time, run at full capacity
             power_setpoint = self.rated_capacity
-        elif current_time < 40 * self.controller_base_unit * 60:  # 40 minutes in seconds
-            # Between 10 and 40 minutes: shut down
+        elif current_time < 0.15 * self.total_simulation_time:
+            # Between 5% and 15% of simulation time: shut down
             power_setpoint = 0.0
-        elif current_time < 120 * self.controller_base_unit * 60:  # 120 minutes in seconds
-            # Between 40 and 120 minutes: signal to run at full capacity
+        elif current_time < 0.45 * self.total_simulation_time:
+            # Between 15% and 45% of simulation time: signal to run at full capacity
             power_setpoint = self.rated_capacity
-        elif current_time < 180 * self.controller_base_unit * 60:  # 180 minutes in seconds
-            # Between 120 and 180 minutes: reduce power to 50% of rated capacity
+        elif current_time < 0.65 * self.total_simulation_time:
+            # Between 45% and 65% of simulation time: reduce power to 50% of rated capacity
             power_setpoint = 0.5 * self.rated_capacity
-        elif current_time < 210 * self.controller_base_unit * 60:  # 210 minutes in seconds
-            # Between 180 and 210 minutes: reduce power to 10% of rated capacity
+        elif current_time < 0.75 * self.total_simulation_time:
+            # Between 65% and 75% of simulation time: reduce power to 10% of rated capacity
             power_setpoint = 0.1 * self.rated_capacity
-        elif current_time < 240 * self.controller_base_unit * 60:  # 240 minutes in seconds
-            # Between 210 and 240 minutes: increase power to 100% of rated capacity
+        elif current_time < 0.9 * self.total_simulation_time:  #
+            # Between 75% and 90% of simulation time: increase power to 100% of rated capacity
             power_setpoint = self.rated_capacity
         else:
-            # After 240 minutes: shut down
+            # After 90% of simulation time: shut down
             power_setpoint = 0.0
 
         h_dict[self.component_name]["power_setpoint"] = power_setpoint

--- a/examples/08_hard_coal_steam_turbine/hercules_runscript.py
+++ b/examples/08_hard_coal_steam_turbine/hercules_runscript.py
@@ -1,0 +1,89 @@
+"""Example 07: Hard Coal Steam Turbine (HCST) simulation.
+
+This example demonstrates a simple hard coal steam turbine (HCST) that:
+- Starts on at rated capacity (100 MW)
+- At 10 minutes, receives a shutdown command and begins ramping down
+- At ~20 minutes, reaches 0 MW and transitions to off
+- At 40 minutes, receives a turn-on command with a setpoint of 100% of rated capacity
+- At ~80 minutes, 1 hour down-time minimum is reached and the turbine begins hot starting
+- At ~87 minutes, hot start completes, continues ramping up to 100% of rated capacity
+- At 120 minutes, receives a command to reduce power to 50% of rated capacity
+- At 180 minutes, receives a command to reduce power to 10% of rated capacity
+        (note this is below the minimum stable load)
+- At 210 minutes, receives a command to increase power to 100% of rated capacity
+- At 240 minutes (4 hours), receives a shutdown command
+- Simulation runs for 6 hours total with 1 minute time steps
+"""
+
+from hercules.hercules_model import HerculesModel
+from hercules.utilities_examples import prepare_output_directory
+
+prepare_output_directory()
+
+# Initialize the Hercules model
+hmodel = HerculesModel("hercules_input.yaml")
+
+
+class ControllerHCST:
+    """Controller implementing the HCST schedule described in the module docstring."""
+
+    def __init__(self, h_dict, component_name="hard_coal_steam_turbine"):
+        """Initialize the controller.
+
+        Args:
+            h_dict (dict): The hercules input dictionary.
+
+        """
+        self.component_name = component_name
+        self.rated_capacity = h_dict[self.component_name]["rated_capacity"]
+        # Controller operates in 1-minute intervals, so base unit is an hour
+        self.controller_base_unit = 45
+
+    def step(self, h_dict):
+        """Execute one control step.
+
+        Args:
+            h_dict (dict): The hercules input dictionary.
+
+        Returns:
+            dict: The updated hercules input dictionary.
+
+        """
+        current_time = h_dict["time"]
+
+        # NOTE: update doc strings to reflect base unit scaling
+        # Determine power setpoint based on time
+        if current_time < 10 * self.controller_base_unit * 60:  # 10 minutes in seconds
+            # Before 10 minutes: run at full capacity
+            power_setpoint = self.rated_capacity
+        elif current_time < 40 * self.controller_base_unit * 60:  # 40 minutes in seconds
+            # Between 10 and 40 minutes: shut down
+            power_setpoint = 0.0
+        elif current_time < 120 * self.controller_base_unit * 60:  # 120 minutes in seconds
+            # Between 40 and 120 minutes: signal to run at full capacity
+            power_setpoint = self.rated_capacity
+        elif current_time < 180 * self.controller_base_unit * 60:  # 180 minutes in seconds
+            # Between 120 and 180 minutes: reduce power to 50% of rated capacity
+            power_setpoint = 0.5 * self.rated_capacity
+        elif current_time < 210 * self.controller_base_unit * 60:  # 210 minutes in seconds
+            # Between 180 and 210 minutes: reduce power to 10% of rated capacity
+            power_setpoint = 0.1 * self.rated_capacity
+        elif current_time < 240 * self.controller_base_unit * 60:  # 240 minutes in seconds
+            # Between 210 and 240 minutes: increase power to 100% of rated capacity
+            power_setpoint = self.rated_capacity
+        else:
+            # After 240 minutes: shut down
+            power_setpoint = 0.0
+
+        h_dict[self.component_name]["power_setpoint"] = power_setpoint
+
+        return h_dict
+
+
+# Instantiate the controller and assign to the Hercules model
+hmodel.assign_controller(ControllerHCST(hmodel.h_dict))
+
+# Run the simulation
+hmodel.run()
+
+hmodel.logger.info("Process completed successfully")

--- a/examples/08_hard_coal_steam_turbine/hercules_runscript.py
+++ b/examples/08_hard_coal_steam_turbine/hercules_runscript.py
@@ -1,18 +1,18 @@
 """Example 07: Hard Coal Steam Turbine (HCST) simulation.
 
 This example demonstrates a simple hard coal steam turbine (HCST) that:
-- Starts on at rated capacity (100 MW)
-- At 10 minutes, receives a shutdown command and begins ramping down
-- At ~20 minutes, reaches 0 MW and transitions to off
-- At 40 minutes, receives a turn-on command with a setpoint of 100% of rated capacity
-- At ~80 minutes, 1 hour down-time minimum is reached and the turbine begins hot starting
-- At ~87 minutes, hot start completes, continues ramping up to 100% of rated capacity
-- At 120 minutes, receives a command to reduce power to 50% of rated capacity
-- At 180 minutes, receives a command to reduce power to 10% of rated capacity
+- Starts on at rated capacity
+- Receives a shutdown command and begins ramping down
+- Transitions to off
+- Receives a turn-on command with a setpoint of 100% of rated capacity
+- Minimum down-time requirement is reached and the turbine begins ramping up
+- Ramps up to 100% of rated capacity
+- Receives a command to reduce power to 50% of rated capacity
+- Receives a command to reduce power to 10% of rated capacity
         (note this is below the minimum stable load)
-- At 210 minutes, receives a command to increase power to 100% of rated capacity
-- At 240 minutes (4 hours), receives a shutdown command
-- Simulation runs for 6 hours total with 1 minute time steps
+- Receives a command to increase power to 100% of rated capacity
+- Receives a shutdown command
+- Simulation runs for 10 days total with 1 minute time steps
 """
 
 from hercules.hercules_model import HerculesModel

--- a/examples/08_hard_coal_steam_turbine/plot_outputs.py
+++ b/examples/08_hard_coal_steam_turbine/plot_outputs.py
@@ -21,6 +21,8 @@ h_dict = ho.h_dict
 # Convert time to hours for easier reading
 time_hours = df["time"] / 60 / 60
 
+print("TONNES OF COAL USED:", df[component_name + ".fuel_volume_rate"].sum() * h_dict["dt"])
+
 fig, axarr = plt.subplots(4, 1, sharex=True, figsize=(10, 10))
 
 # Plot the power output and setpoint
@@ -87,7 +89,7 @@ ax.set_ylabel("Fuel [m³/s]")
 ax.set_title("Fuel Volume Rate")
 ax.grid(True)
 
-ax.set_xlabel("Time [minutes]")
+ax.set_xlabel("Time [hours]")
 
 plt.tight_layout()
 plt.show()

--- a/examples/08_hard_coal_steam_turbine/plot_outputs.py
+++ b/examples/08_hard_coal_steam_turbine/plot_outputs.py
@@ -1,0 +1,93 @@
+# Plot the outputs of the simulation for the OCGT example
+
+import matplotlib.pyplot as plt
+from hercules import HerculesOutput
+
+# Read the Hercules output file using HerculesOutput
+ho = HerculesOutput("outputs/hercules_output.h5")
+component_name = "hard_coal_steam_turbine"  # Change to "open_cycle_gas_turbine" if needed
+
+# Print metadata information
+print("Simulation Metadata:")
+ho.print_metadata()
+print()
+
+# Create a shortcut to the dataframe
+df = ho.df
+
+# Get the h_dict from metadata
+h_dict = ho.h_dict
+
+# Convert time to hours for easier reading
+time_hours = df["time"] / 60 / 60
+
+fig, axarr = plt.subplots(4, 1, sharex=True, figsize=(10, 10))
+
+# Plot the power output and setpoint
+ax = axarr[0]
+ax.plot(time_hours, df[component_name + ".power"] / 1000, label="Power Output", color="b")
+ax.plot(
+    time_hours,
+    df[component_name + ".power_setpoint"] / 1000,
+    label="Power Setpoint",
+    color="r",
+    linestyle="--",
+)
+ax.axhline(
+    h_dict[component_name]["rated_capacity"] / 1000,
+    color="gray",
+    linestyle=":",
+    label="Rated Capacity",
+)
+ax.axhline(
+    h_dict[component_name]["min_stable_load_fraction"]
+    * h_dict[component_name]["rated_capacity"]
+    / 1000,
+    color="gray",
+    linestyle="--",
+    label="Minimum Stable Load",
+)
+ax.set_ylabel("Power [MW]")
+ax.set_title("Open Cycle Gas Turbine Power Output")
+ax.legend()
+ax.grid(True)
+
+# Plot the state
+ax = axarr[1]
+ax.plot(time_hours, df[component_name + ".state"], label="State", color="k")
+ax.set_ylabel("State")
+ax.set_yticks([0, 1, 2, 3, 4, 5])
+ax.set_yticklabels(["Off", "Hot Starting", "Warm Starting", "Cold Starting", "On", "Stopping"])
+ax.set_title(
+    "Turbine State (0=Off, 1=Hot Starting, 2=Warm Starting, 3=Cold Starting, 4=On, 5=Stopping)"
+)
+ax.grid(True)
+
+# Plot the efficiency
+ax = axarr[2]
+ax.plot(
+    time_hours,
+    df[component_name + ".efficiency"] * 100,
+    label="Efficiency",
+    color="g",
+)
+ax.set_ylabel("Efficiency [%]")
+ax.set_title("Thermal Efficiency")
+ax.grid(True)
+
+# Plot the fuel consumption
+ax = axarr[3]
+ax.plot(
+    time_hours,
+    df[component_name + ".fuel_volume_rate"],
+    label="Fuel Volume Rate",
+    color="orange",
+)
+ax.set_ylabel("Fuel [m³/s]")
+ax.set_title("Fuel Volume Rate")
+ax.grid(True)
+
+ax.set_xlabel("Time [minutes]")
+
+plt.tight_layout()
+plt.show()

--- a/hercules/hybrid_plant.py
+++ b/hercules/hybrid_plant.py
@@ -3,6 +3,7 @@ import numpy as np
 from hercules.plant_components.battery_lithium_ion import BatteryLithiumIon
 from hercules.plant_components.battery_simple import BatterySimple
 from hercules.plant_components.electrolyzer_plant import ElectrolyzerPlant
+from hercules.plant_components.hard_coal_steam_turbine import HardCoalSteamTurbine
 from hercules.plant_components.open_cycle_gas_turbine import OpenCycleGasTurbine
 from hercules.plant_components.solar_pysam_pvwatts import SolarPySAMPVWatts
 from hercules.plant_components.wind_farm import WindFarm
@@ -18,6 +19,7 @@ COMPONENT_REGISTRY = {
     "BatteryLithiumIon": BatteryLithiumIon,
     "ElectrolyzerPlant": ElectrolyzerPlant,
     "OpenCycleGasTurbine": OpenCycleGasTurbine,
+    "HardCoalSteamTurbine": HardCoalSteamTurbine,
 }
 
 # Derived from registry keys for validation in utilities.py

--- a/hercules/plant_components/hard_coal_steam_turbine.py
+++ b/hercules/plant_components/hard_coal_steam_turbine.py
@@ -72,7 +72,7 @@ class HardCoalSteamTurbine(ThermalComponentBase):
                     efficiency arrays (both as fractions 0-1). Efficiency values must
                     be HHV net plant efficiencies. Default values are taken from [2,3]:
                     power_fraction = [1.0, 0.5, 0.3],
-                    efficiency = [0.35, 0.32, 0.32].
+                    efficiency = [0.35, 0.32, 0.30].
 
             component_name (str): Unique name for this instance (the YAML top-level key).
         """
@@ -112,7 +112,7 @@ class HardCoalSteamTurbine(ThermalComponentBase):
         if "efficiency_table" not in h_dict[component_name]:
             h_dict[component_name]["efficiency_table"] = {
                 "power_fraction": [1.0, 0.5, 0.3],
-                "efficiency": [0.35, 0.32, 0.32],
+                "efficiency": [0.35, 0.32, 0.30],
             }
 
         # Call the base class init (sets self.component_name and self.component_type)

--- a/hercules/plant_components/hard_coal_steam_turbine.py
+++ b/hercules/plant_components/hard_coal_steam_turbine.py
@@ -1,0 +1,119 @@
+"""
+Hard Coal Steam Turbine Class.
+
+Hard coal steam turbine model is a subclass of the ThermalComponentBase class.
+It implements the model as presented in [1], [2], [3], and [4].
+
+Like other subclasses of ThermalComponentBase, it inherits the main control functions,
+and adds defaults for many variables based on [1], [2], [3], and [4].
+
+References:
+
+[1] Agora Energiewende (2017): Flexibility in thermal power plants
+     With a focus on existing coal-fired power plants.
+[2] IRENA (2019), Innovation landscape brief: Flexibility in conventional power plants,
+    International Renewable Energy Agency, Abu Dhabi.
+[3] Schmitt, Tommy, Sarah Leptinsky, Marc Turner, Alex Zoelle, Chuck White, Sydney Hughes,
+    Sally Homsy, et al. “Cost And Performance Baseline for Fossil Energy Plants Volume 1:
+    Bituminous Coal and Natural Gas to Electricity.” Pittsburgh, PA: National Energy Technology
+    Laboratory, October 14, 2022b. https://doi.org/10.2172/1893822.
+[4] I. Staffell, "The Energy and Fuel Data Sheet," University of Birmingham, March 2011.
+    https://claverton-energy.com/cms4/wp-content/uploads/2012/08/the_energy_and_fuel_data_sheet.pdf
+"""
+
+from hercules.plant_components.thermal_component_base import ThermalComponentBase
+
+
+class HardCoalSteamTurbine(ThermalComponentBase):
+    """Hard coal steam turbine model.
+
+    This model represents a hard coal steam turbine with state
+    management, ramp rate constraints, minimum stable load, and fuel consumption
+    tracking.  Note it is a subclass of the ThermalComponentBase class.
+
+    All efficiency values are HHV (Higher Heating Value) net plant efficiencies.
+
+    NOTE: if minimum downtime is 48 hours, then hot start = warm start = cold start = 7.5 hours
+        as per [1].
+    """
+
+    def __init__(self, h_dict, component_name):
+        """Initialize the HardCoalSteamTurbine class.
+
+        Args:
+            h_dict (dict): Dictionary containing simulation parameters including:
+                - rated_capacity: Maximum power output in kW
+                - min_stable_load_fraction: Optional, minimum operating point as fraction (0-1).
+                    Default: 0.30 (30%) [2]
+                - ramp_rate_fraction: Optional, maximum rate of power increase/decrease
+                    as fraction of rated capacity per minute. Default: 0.03 (3%) [1,2]
+                - run_up_rate_fraction: Optional, maximum rate of power increase during startup
+                    as fraction of rated capacity per minute. Default: ramp_rate_fraction
+                - hot_startup_time: Optional, time to reach min_stable_load_fraction from off
+                    in s. Includes both readying time and ramping time.
+                    Default: 27000.0 s (7.5 hours) [1]
+                - warm_startup_time: Optional, time to reach min_stable_load_fraction from off
+                    in s. Includes both readying time and ramping time.
+                    Default: 27000.0 s (7.5 hours) [1]
+                - cold_startup_time: Optional, time to reach min_stable_load_fraction from off
+                    in s. Includes both readying time and ramping time.
+                    Default: 27000.0 s (7.5 hours) [1]
+                - min_up_time: Optional, minimum time unit must remain on in s.
+                    Default: 172800.0 s (48 hours) [2]
+                - min_down_time: Optional, minimum time unit must remain off in s.
+                    Default: 172800.0 s (48 hours) [2]
+                - initial_conditions: Dictionary with initial power (state is
+                    derived automatically: power > 0 means ON, power == 0 means OFF)
+                - hhv: Optional, higher heating value of coal (Bituminous) in J/m³.
+                    Default: 29,310,000,000 J/m³ (29.31 MJ/kg) [4]
+                - fuel_density: Optional, fuel density in kg/m³. https://www.engineeringtoolbox.com/classification-coal-d_164.html
+                    Default: 1000 kg/m³
+                - efficiency_table: Optional, dictionary with power_fraction and
+                    efficiency arrays (both as fractions 0-1). Efficiency values must
+                    be HHV net plant efficiencies. Default values are taken from [2,3]:
+                    power_fraction = [1.0, 0.5, 0.3],
+                    efficiency = [0.35, 0.32, 0.32].
+
+            component_name (str): Unique name for this instance (the YAML top-level key).
+        """
+
+        # Apply fixed default parameters based on [1], [2] and [3]
+        # back into the h_dict if they are not provided
+        if "min_stable_load_fraction" not in h_dict[component_name]:
+            h_dict[component_name]["min_stable_load_fraction"] = 0.30
+        if "ramp_rate_fraction" not in h_dict[component_name]:
+            h_dict[component_name]["ramp_rate_fraction"] = 0.03
+        if "hot_startup_time" not in h_dict[component_name]:
+            h_dict[component_name]["hot_startup_time"] = 27000.0
+        if "warm_startup_time" not in h_dict[component_name]:
+            h_dict[component_name]["warm_startup_time"] = 27000.0
+        if "cold_startup_time" not in h_dict[component_name]:
+            h_dict[component_name]["cold_startup_time"] = 27000.0
+        if "min_up_time" not in h_dict[component_name]:
+            h_dict[component_name]["min_up_time"] = 172800.0
+        if "min_down_time" not in h_dict[component_name]:
+            h_dict[component_name]["min_down_time"] = 172800.0
+
+        # If the run_up_rate_fraction is not provided, it defaults to the ramp_rate_fraction
+        if "run_up_rate_fraction" not in h_dict[component_name]:
+            h_dict[component_name]["run_up_rate_fraction"] = h_dict[component_name][
+                "ramp_rate_fraction"
+            ]
+
+        # Default HHV for coal (Bituminous) (29310 MJ/m³) from [4]
+        if "hhv" not in h_dict[component_name]:
+            h_dict[component_name]["hhv"] = 29310000000  # J/m³ (29310 MJ/m³)
+
+        # Default fuel density for coal (Bituminous) (1000 kg/m³)
+        if "fuel_density" not in h_dict[component_name]:
+            h_dict[component_name]["fuel_density"] = 1000.0  # kg/m³
+
+        # Default HHV net plant efficiency table based on [2]:
+        if "efficiency_table" not in h_dict[component_name]:
+            h_dict[component_name]["efficiency_table"] = {
+                "power_fraction": [1.0, 0.5, 0.3],
+                "efficiency": [0.35, 0.32, 0.32],
+            }
+
+        # Call the base class init (sets self.component_name and self.component_type)
+        super().__init__(h_dict, component_name)

--- a/hercules/plant_components/hard_coal_steam_turbine.py
+++ b/hercules/plant_components/hard_coal_steam_turbine.py
@@ -77,7 +77,7 @@ class HardCoalSteamTurbine(ThermalComponentBase):
             component_name (str): Unique name for this instance (the YAML top-level key).
         """
 
-        # Apply fixed default parameters based on [1], [2] and [3]
+        # Apply fixed default parameters based on references
         # back into the h_dict if they are not provided
         if "min_stable_load_fraction" not in h_dict[component_name]:
             h_dict[component_name]["min_stable_load_fraction"] = 0.30
@@ -100,11 +100,11 @@ class HardCoalSteamTurbine(ThermalComponentBase):
                 "ramp_rate_fraction"
             ]
 
-        # Default HHV for coal (Bituminous) (29310 MJ/m³) from [4]
+        # Default HHV for coal (Bituminous)
         if "hhv" not in h_dict[component_name]:
             h_dict[component_name]["hhv"] = 29310000000  # J/m³ (29310 MJ/m³)
 
-        # Default fuel density for coal (Bituminous) (1000 kg/m³)
+        # Default fuel density for coal (Bituminous)
         if "fuel_density" not in h_dict[component_name]:
             h_dict[component_name]["fuel_density"] = 1000.0  # kg/m³
 

--- a/tests/hard_coal_steam_turbine_test.py
+++ b/tests/hard_coal_steam_turbine_test.py
@@ -21,11 +21,11 @@ def test_default_inputs():
     """Test that HardCoalSteamTurbine uses default inputs when not provided."""
     h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
 
-    # Test that the ramp_rate_fraction is 0.04 (from test fixture)
+    # Test that the ramp_rate_fraction input is correct from input dict
     hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
     assert hcst.ramp_rate_fraction == 0.04
 
-    # Test that the run_up_rate_fraction is 0.02 (from test fixture)
+    # Test that the run_up_rate_fraction input is correct from input dict
     assert hcst.run_up_rate_fraction == 0.02
 
     # Test that if the run_up_rate_fraction is not provided,
@@ -77,7 +77,6 @@ def test_default_hhv():
     h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
     del h_dict["hard_coal_steam_turbine"]["hhv"]
     hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
-    # Default HHV for coal (Bituminous) (29310 MJ/m³) from [4]
     assert hcst.hhv == 29310000000
 
 
@@ -87,7 +86,6 @@ def test_default_fuel_density():
     if "fuel_density" in h_dict["hard_coal_steam_turbine"]:
         del h_dict["hard_coal_steam_turbine"]["fuel_density"]
     hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
-    # Default fuel density for coal (Bituminous) is 1000 kg/m³
     assert hcst.fuel_density == 1000.0
 
 
@@ -99,7 +97,6 @@ def test_default_efficiency_table():
     h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
     del h_dict["hard_coal_steam_turbine"]["efficiency_table"]
     hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
-    # Default HHV net plant efficiency table based on [2]:
     np.testing.assert_array_equal(
         hcst.efficiency_power_fraction,
         np.array([0.3, 0.5, 1.0], dtype=hercules_float_type),

--- a/tests/hard_coal_steam_turbine_test.py
+++ b/tests/hard_coal_steam_turbine_test.py
@@ -1,0 +1,110 @@
+import copy
+
+import numpy as np
+from hercules.plant_components.hard_coal_steam_turbine import HardCoalSteamTurbine
+from hercules.utilities import hercules_float_type
+
+from .test_inputs.h_dict import (
+    h_dict_hard_coal_steam_turbine,
+)
+
+
+def test_init_from_dict():
+    """Test that HardCoalSteamTurbine can be initialized from a dictionary."""
+    hcst = HardCoalSteamTurbine(
+        copy.deepcopy(h_dict_hard_coal_steam_turbine), "hard_coal_steam_turbine"
+    )
+    assert hcst is not None
+
+
+def test_default_inputs():
+    """Test that HardCoalSteamTurbine uses default inputs when not provided."""
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+
+    # Test that the ramp_rate_fraction is 0.04 (from test fixture)
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    assert hcst.ramp_rate_fraction == 0.04
+
+    # Test that the run_up_rate_fraction is 0.02 (from test fixture)
+    assert hcst.run_up_rate_fraction == 0.02
+
+    # Test that if the run_up_rate_fraction is not provided,
+    # it defaults to the ramp_rate_fraction
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["run_up_rate_fraction"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    assert hcst.run_up_rate_fraction == hcst.ramp_rate_fraction
+
+    # Now test that the default value of the ramp_rate_fraction is
+    # applied to both the ramp_rate_fraction and the run_up_rate_fraction
+    # if they are both not provided
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["ramp_rate_fraction"]
+    del h_dict["hard_coal_steam_turbine"]["run_up_rate_fraction"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    assert hcst.ramp_rate_fraction == 0.03
+    assert hcst.run_up_rate_fraction == 0.03
+
+    # Test the remaining default values
+    # Delete startup times first, since changing min_stable_load_fraction and
+    # ramp rates affects ramp_time validation against startup times
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["ramp_rate_fraction"]
+    del h_dict["hard_coal_steam_turbine"]["run_up_rate_fraction"]
+    del h_dict["hard_coal_steam_turbine"]["cold_startup_time"]
+    del h_dict["hard_coal_steam_turbine"]["warm_startup_time"]
+    del h_dict["hard_coal_steam_turbine"]["hot_startup_time"]
+    del h_dict["hard_coal_steam_turbine"]["min_stable_load_fraction"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    assert hcst.min_stable_load_fraction == 0.30
+    assert hcst.hot_startup_time == 7.5 * 60.0 * 60.0  # 7.5 hours in seconds
+    assert hcst.warm_startup_time == 7.5 * 60.0 * 60.0  # 7.5 hours in seconds
+    assert hcst.cold_startup_time == 7.5 * 60.0 * 60.0  # 7.5 hours in seconds
+
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["min_up_time"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    assert hcst.min_up_time == 48 * 60.0 * 60.0  # 48 hours in seconds
+
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["min_down_time"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    assert hcst.min_down_time == 48 * 60.0 * 60.0  # 48 hours in seconds
+
+
+def test_default_hhv():
+    """Test that HardCoalSteamTurbine provides default HHV for bituminous coal from [4]."""
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["hhv"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    # Default HHV for coal (Bituminous) (29310 MJ/m³) from [4]
+    assert hcst.hhv == 29310000000
+
+
+def test_default_fuel_density():
+    """Test that HardCoalSteamTurbine provides default fuel density."""
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    if "fuel_density" in h_dict["hard_coal_steam_turbine"]:
+        del h_dict["hard_coal_steam_turbine"]["fuel_density"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    # Default fuel density for coal (Bituminous) is 1000 kg/m³
+    assert hcst.fuel_density == 1000.0
+
+
+def test_default_efficiency_table():
+    """Test that HardCoalSteamTurbine provides default HHV net efficiency table.
+
+    Default values are taken from [2,3]
+    """
+    h_dict = copy.deepcopy(h_dict_hard_coal_steam_turbine)
+    del h_dict["hard_coal_steam_turbine"]["efficiency_table"]
+    hcst = HardCoalSteamTurbine(h_dict, "hard_coal_steam_turbine")
+    # Default HHV net plant efficiency table based on [2]:
+    np.testing.assert_array_equal(
+        hcst.efficiency_power_fraction,
+        np.array([0.3, 0.5, 1.0], dtype=hercules_float_type),
+    )
+    np.testing.assert_array_equal(
+        hcst.efficiency_values,
+        np.array([0.30, 0.32, 0.35], dtype=hercules_float_type),
+    )

--- a/tests/test_inputs/h_dict.py
+++ b/tests/test_inputs/h_dict.py
@@ -152,6 +152,25 @@ open_cycle_gas_turbine = {
     },
 }
 
+hard_coal_steam_turbine = {
+    "component_type": "HardCoalSteamTurbine",
+    "rated_capacity": 500000,  # kW (500 MW)
+    "min_stable_load_fraction": 0.3,  # 30% minimum operating point
+    "ramp_rate_fraction": 0.04,  # 4%/min ramp rate
+    "run_up_rate_fraction": 0.02,  # 2%/min run up rate
+    "hot_startup_time": 27000.0,  # 7.5 hours
+    "warm_startup_time": 27000.0,  # 7.5 hours
+    "cold_startup_time": 27000.0,  # 7.5 hours
+    "min_up_time": 172800,  # 48 hours
+    "min_down_time": 172800,  # 48 hour
+    "hhv": 29310000000,  # J/m³ for bituminous coal (29.31 MJ/m³) [4]
+    "fuel_density": 1000,  # kg/m³ for bituminous coal
+    "initial_conditions": {"power": 1000},  # power > 0 implies ON state
+    "efficiency_table": {
+        "power_fraction": [1.0, 0.5, 0.3],
+        "efficiency": [0.35, 0.32, 0.30],
+    },
+}
 
 electrolyzer = {
     "component_type": "ElectrolyzerPlant",
@@ -379,4 +398,17 @@ h_dict_open_cycle_gas_turbine = {
     "time": 0.0,
     "plant": plant,
     "open_cycle_gas_turbine": open_cycle_gas_turbine,
+}
+
+h_dict_hard_coal_steam_turbine = {
+    "dt": 1.0,
+    "starttime": 0.0,
+    "endtime": 10.0,
+    "starttime_utc": pd.to_datetime("2018-05-10 12:31:00", utc=True),
+    "endtime_utc": pd.to_datetime("2018-05-10 12:31:10", utc=True),
+    "verbose": False,
+    "step": 0,
+    "time": 0.0,
+    "plant": plant,
+    "hard_coal_steam_turbine": hard_coal_steam_turbine,
 }


### PR DESCRIPTION
This model adds a class to represent coal plant using `ThermalPlantBaseClass` as an initial starting point. This class defines defaults for coal plant operation based on the resource cited in the class.

- [x] Add class
- [x] Update docs
- [x] Add tests
- [x] Example (if needed)