### PR TITLE
Fix number check

### DIFF
--- a/hercules/plant_components/thermal_component_base.py
+++ b/hercules/plant_components/thermal_component_base.py
@@ -125,23 +125,23 @@ class ThermalComponentBase(ComponentBase):
         self.min_down_time = component_dict["min_down_time"]  # s
 
         # Check all required parameters are numbers
-        if not isinstance(self.rated_capacity, (int, float)):
+        if not isinstance(self.rated_capacity, (int, float, hercules_float_type)):
             raise ValueError("rated_capacity must be a number")
-        if not isinstance(self.min_stable_load_fraction, (int, float)):
+        if not isinstance(self.min_stable_load_fraction, (int, float, hercules_float_type)):
             raise ValueError("min_stable_load_fraction must be a number")
-        if not isinstance(self.ramp_rate_fraction, (int, float)):
+        if not isinstance(self.ramp_rate_fraction, (int, float, hercules_float_type)):
             raise ValueError("ramp_rate_fraction must be a number")
-        if not isinstance(self.run_up_rate_fraction, (int, float)):
+        if not isinstance(self.run_up_rate_fraction, (int, float, hercules_float_type)):
             raise ValueError("run_up_rate_fraction must be a number")
-        if not isinstance(self.hot_startup_time, (int, float)):
+        if not isinstance(self.hot_startup_time, (int, float, hercules_float_type)):
             raise ValueError("hot_startup_time must be a number")
-        if not isinstance(self.warm_startup_time, (int, float)):
+        if not isinstance(self.warm_startup_time, (int, float, hercules_float_type)):
             raise ValueError("warm_startup_time must be a number")
-        if not isinstance(self.cold_startup_time, (int, float)):
+        if not isinstance(self.cold_startup_time, (int, float, hercules_float_type)):
             raise ValueError("cold_startup_time must be a number")
-        if not isinstance(self.min_up_time, (int, float)):
+        if not isinstance(self.min_up_time, (int, float, hercules_float_type)):
             raise ValueError("min_up_time must be a number")
-        if not isinstance(self.min_down_time, (int, float)):
+        if not isinstance(self.min_down_time, (int, float, hercules_float_type)):
             raise ValueError("min_down_time must be a number")
 
         # Check parameters
@@ -230,13 +230,13 @@ class ThermalComponentBase(ComponentBase):
         efficiency_table = component_dict["efficiency_table"]
 
         # Validate hhv
-        if not isinstance(self.hhv, (int, float)):
+        if not isinstance(self.hhv, (int, float, hercules_float_type)):
             raise ValueError("hhv must be a number")
         if self.hhv <= 0:
             raise ValueError("hhv must be greater than 0")
 
         # Validate fuel_density
-        if not isinstance(self.fuel_density, (int, float)):
+        if not isinstance(self.fuel_density, (int, float, hercules_float_type)):
             raise ValueError("fuel_density must be a number")
         if self.fuel_density <= 0:
             raise ValueError("fuel_density must be greater than 0")
@@ -323,7 +323,7 @@ class ThermalComponentBase(ComponentBase):
         power_setpoint = h_dict[self.component_name]["power_setpoint"]
 
         # Check that the power setpoint is a number
-        if not isinstance(power_setpoint, (int, float)):
+        if not isinstance(power_setpoint, (int, float, hercules_float_type)):
             raise ValueError("power_setpoint must be a number")
 
         # Update time in current state

--- a/tests/wind_farm_direct_test.py
+++ b/tests/wind_farm_direct_test.py
@@ -59,7 +59,7 @@ def test_wind_farm_direct_step():
     assert len(result["wind_farm"]["turbine_powers"]) == 3
     assert isinstance(result["wind_farm"]["turbine_powers"], np.ndarray)
     assert "power" in result["wind_farm"]
-    assert isinstance(result["wind_farm"]["power"], (int, float))
+    assert isinstance(result["wind_farm"]["power"], (int, float, hercules_float_type))
 
     # Verify no wake deficits applied
     assert np.all(wind_sim.floris_wake_deficits == 0.0)

--- a/tests/wind_farm_dynamic_floris_test.py
+++ b/tests/wind_farm_dynamic_floris_test.py
@@ -105,7 +105,7 @@ def test_wind_farm_step():
     assert len(result["wind_farm"]["turbine_powers"]) == 3
     assert isinstance(result["wind_farm"]["turbine_powers"], np.ndarray)
     assert "power" in result["wind_farm"]
-    assert isinstance(result["wind_farm"]["power"], (int, float))
+    assert isinstance(result["wind_farm"]["power"], (int, float, hercules_float_type))
 
 
 def test_wind_farm_time_utc_conversion():

--- a/tests/wind_farm_precom_floris_test.py
+++ b/tests/wind_farm_precom_floris_test.py
@@ -111,7 +111,7 @@ def test_wind_farm_precom_floris_step():
     assert len(result["wind_farm"]["turbine_powers"]) == 3
     assert isinstance(result["wind_farm"]["turbine_powers"], np.ndarray)
     assert "power" in result["wind_farm"]
-    assert isinstance(result["wind_farm"]["power"], (int, float))
+    assert isinstance(result["wind_farm"]["power"], (int, float, hercules_float_type))
 
 
 def test_wind_farm_precom_floris_power_setpoint_applies():


### PR DESCRIPTION
This PR fixes a small issue where `isinstance(x, (int, float))` doesn't match `np.float32` values (which is what `hercules_float_type` is), so these checks would incorrectly reject valid numeric inputs.  This PR simply corrects each occurence to also check for `hercules_float_type`