### PR TITLE
check for nan

### DIFF
--- a/hercules/plant_components/battery_lithium_ion.py
+++ b/hercules/plant_components/battery_lithium_ion.py
@@ -334,6 +334,8 @@ class BatteryLithiumIon(ComponentBase):
         """
 
         P_signal = h_dict[self.component_name]["power_setpoint"]  # [kW] requested power
+        if np.isnan(P_signal):
+            raise ValueError(f"{self.component_name}: power_setpoint is NaN")
         if self.allow_grid_power_consumption:
             P_avail = np.inf
         else:

--- a/hercules/plant_components/battery_simple.py
+++ b/hercules/plant_components/battery_simple.py
@@ -250,6 +250,8 @@ class BatterySimple(ComponentBase):
 
         # Power available for the battery to use for charging (should be >=0)
         power_setpoint = h_dict[self.component_name]["power_setpoint"]
+        if np.isnan(power_setpoint):
+            raise ValueError(f"{self.component_name}: power_setpoint is NaN")
         # Power signal desired by the controller
         if self.allow_grid_power_consumption:
             P_avail = np.inf

--- a/hercules/plant_components/solar_pysam_base.py
+++ b/hercules/plant_components/solar_pysam_base.py
@@ -254,7 +254,10 @@ class SolarPySAMBase(ComponentBase):
         self.power = self.power_uncurtailed[step]
 
         # Apply control
-        self.control(h_dict[self.component_name]["power_setpoint"])
+        power_setpoint = h_dict[self.component_name]["power_setpoint"]
+        if np.isnan(power_setpoint):
+            raise ValueError(f"{self.component_name}: power_setpoint is NaN")
+        self.control(power_setpoint)
 
         if self.power < 0.0:
             self.power = 0.0

--- a/hercules/plant_components/thermal_component_base.py
+++ b/hercules/plant_components/thermal_component_base.py
@@ -322,9 +322,11 @@ class ThermalComponentBase(ComponentBase):
         # Get power setpoint from controller
         power_setpoint = h_dict[self.component_name]["power_setpoint"]
 
-        # Check that the power setpoint is a number
+        # Check that the power setpoint is a valid number
         if not isinstance(power_setpoint, (int, float)):
             raise ValueError("power_setpoint must be a number")
+        if np.isnan(power_setpoint):
+            raise ValueError(f"{self.component_name}: power_setpoint is NaN")
 
         # Update time in current state
         self.time_in_state += self.dt

--- a/hercules/plant_components/wind_farm.py
+++ b/hercules/plant_components/wind_farm.py
@@ -670,6 +670,8 @@ class WindFarm(ComponentBase):
 
         # Grab the instantaneous turbine power setpoint signal
         turbine_power_setpoints = h_dict[self.component_name]["turbine_power_setpoints"]
+        if np.any(np.isnan(turbine_power_setpoints)):
+            raise ValueError(f"{self.component_name}: turbine_power_setpoints contains NaN")
 
         # Update wind speeds based on wake model
         if self.wake_method == "dynamic":


### PR DESCRIPTION
The current version of hercules allows for NaN values to be passed into `power_setpoint` for various component.  What the component should then do is ambiguous and leads to unpredictable behavior so this PR adds a test for NaN values to each component that accepts a power_setpoint.  I had thought to add a test at the base level but this was tricky because (a) not all components accept a power_setpoint, and then also even those that do accept it in different forms (wind accepts an array of setpoints to each turbines).  So thought the simplest, most general approach was to leave this test up to each component.