### PR TITLE
Update GitHub workflow to enable ruff format testing for all python versions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -23,7 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[develop]"
     - uses: pre-commit/action@v3.0.0
-      if: matrix.python-version == '3.13'
+      # if: matrix.python-version == '3.13'
     - name: Run tests and collect coverage
       run: |
         # -rA displays the captured output for all tests after they're run

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -23,7 +23,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[develop]"
     - uses: pre-commit/action@v3.0.0
-      # if: matrix.python-version == '3.13'
     - name: Run tests and collect coverage
       run: |
         # -rA displays the captured output for all tests after they're run

--- a/docs/combined_cycle_plant.md
+++ b/docs/combined_cycle_plant.md
@@ -24,8 +24,8 @@ The default HHV net plant efficiency table is based on approximate readings from
 
 | Power Fraction | HHV Net Efficiency |
 |---------------|-------------------|
-| 1.0           | 0.53  |
-| 0.95          | 0.515 |
+| 1.0           | 0.53  | 
+| 0.95          | 0.515 | 
 | 0.90          | 0.52  |
 | 0.85          | 0.52  |
 | 0.80          | 0.52  |

--- a/docs/combined_cycle_plant.md
+++ b/docs/combined_cycle_plant.md
@@ -24,8 +24,8 @@ The default HHV net plant efficiency table is based on approximate readings from
 
 | Power Fraction | HHV Net Efficiency |
 |---------------|-------------------|
-| 1.0           | 0.53  | 
-| 0.95          | 0.515 | 
+| 1.0           | 0.53  |
+| 0.95          | 0.515 |
 | 0.90          | 0.52  |
 | 0.85          | 0.52  |
 | 0.80          | 0.52  |


### PR DESCRIPTION
Previously, ruff formatting was only running for python v3.13, which was leading to some confusing testing errors. This PR enables ruff formatting to be run on all python versions.